### PR TITLE
refactor: remove redundant #playerNodes map

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -9,7 +9,6 @@ import type {
     PlayerUpdatePayload
 } from "./types.js";
 
-
 export interface GatewayPayload {
     op: number;
     d: unknown;
@@ -43,7 +42,6 @@ export class LinkDaveClient extends EventEmitter {
     readonly #sendToShard: SendToShardFn;
     readonly #nodes = new Map<string, Node>();
     readonly #players = new Map<string, Player>();
-    readonly #playerNodes = new Map<string, Node>();
 
     constructor(options: LinkDaveClientOptions) {
         super();
@@ -136,7 +134,6 @@ export class LinkDaveClient extends EventEmitter {
 
         player = new Player(this, guildId, node, options);
         this.#players.set(guildId, player);
-        this.#playerNodes.set(guildId, node);
         node.incrementPlayerCount();
 
         return player;
@@ -152,18 +149,13 @@ export class LinkDaveClient extends EventEmitter {
             return false;
         }
 
-        const node = this.#playerNodes.get(guildId);
-        if (node) {
-            node.decrementPlayerCount();
-        }
-
+        player.node.decrementPlayerCount();
         this.#players.delete(guildId);
-        this.#playerNodes.delete(guildId);
         return true;
     }
 
     getPlayerNode(guildId: string): Node | undefined {
-        return this.#playerNodes.get(guildId);
+        return this.#players.get(guildId)?.node;
     }
 
     get players(): Map<string, Player> {
@@ -230,29 +222,25 @@ export class LinkDaveClient extends EventEmitter {
         event: K,
         data: LinkDaveEvents[K]
     ) {
-        if (this.#playerNodes.get(guildId) !== node) return;
+        const player = this.#players.get(guildId);
+        if (player?.node !== node) return;
+
         this.emit(event, data as LinkDaveManagerEvents[K]);
     }
 
     #handlePlayerUpdate(node: Node, data: PlayerUpdatePayload): void {
-        if (this.#playerNodes.get(data.guild_id) !== node) {
-            return;
-        }
-
         const player = this.#players.get(data.guild_id);
-        if (player) player._updateState(data);
+        if (player?.node !== node) return;
 
+        player._updateState(data);
         this.emit("playerUpdate", data);
     }
 
     #handleNodeDraining(node: Node, data: NodeDrainingPayload): void {
         this.emit("nodeDraining", data);
 
-        for (const [guildId, playerNode] of this.#playerNodes) {
-            if (playerNode !== node) continue;
-
-            const player = this.#players.get(guildId);
-            if (!player) continue;
+        for (const player of this.#players.values()) {
+            if (player.node !== node) continue;
 
             const targetNode = this.#findMigrationTarget(node);
             if (!targetNode) {
@@ -292,10 +280,12 @@ export class LinkDaveClient extends EventEmitter {
     }
 
     _updatePlayerNode(guildId: string, oldNode: Node, newNode: Node): void {
-        if (this.#playerNodes.get(guildId) !== oldNode) return;
+        const player = this.#players.get(guildId);
+
+        // Return if the player is NEITHER on the old node NOR on the new node
+        if (player?.node !== oldNode && player?.node !== newNode) return;
 
         oldNode.decrementPlayerCount();
-        this.#playerNodes.set(guildId, newNode);
         newNode.incrementPlayerCount();
     }
 }

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -281,9 +281,7 @@ export class LinkDaveClient extends EventEmitter {
 
     _updatePlayerNode(guildId: string, oldNode: Node, newNode: Node): void {
         const player = this.#players.get(guildId);
-
-        // Return if the player is NEITHER on the old node NOR on the new node
-        if (player?.node !== oldNode && player?.node !== newNode) return;
+        if (player?.node !== oldNode) return;
 
         oldNode.decrementPlayerCount();
         newNode.incrementPlayerCount();

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -284,8 +284,9 @@ export class Player {
         const oldNode = this.#node;
 
         // Don't send disconnect to old node - we're migrating
-        this.#node = targetNode;
+        // Don't send disconnect to old node - we're migrating
         this.#client._updatePlayerNode(this.#guildId, oldNode, targetNode);
+        this.#node = targetNode;
 
         if (this.#voiceState) {
             this.#node.sendVoiceUpdate({


### PR DESCRIPTION
The #playerNodes map duplicated node references already available via player.node. This change removes the map and updates all usages to derive the node from the player instance, simplifying state management and reducing synchronization overhead.

