### PR TITLE
ci: add workflows for client and server testing

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,4 +1,4 @@
-name: Publish Package to npmjs
+name: client
 
 on:
     push:
@@ -10,7 +10,8 @@ permissions:
     contents: read
 
 jobs:
-    publish:
+    build:
+        name: Publish NPM
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -1,4 +1,4 @@
-name: Publish to GHCR
+name: server
 
 on:
     push:
@@ -10,8 +10,8 @@ permissions:
     packages: write
 
 jobs:
-    build-and-push:
-        name: Build and Push to GHCR
+    build:
+        name: Publish GHCR
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -1,4 +1,4 @@
-name: Test client package
+name: client
 
 on:
     pull_request:
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
     test:
+        name: Test Client
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -1,0 +1,30 @@
+name: Test client package
+
+on:
+    pull_request:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "latest"
+
+            - run: bun install --frozen-lockfile
+              working-directory: ./client
+
+            - run: bun run build
+              working-directory: ./client
+
+            - run: bunx eslint . --no-fix
+              working-directory: ./client

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -14,6 +14,6 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Build Docker image
               run: docker build .

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,4 +1,4 @@
-name: Test server
+name: server
 
 on:
     pull_request:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     test:
-        name: Build and Push to GHCR
+        name: Test Srver
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -1,0 +1,19 @@
+name: Test server
+
+on:
+    pull_request:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
+jobs:
+    test:
+        name: Build and Push to GHCR
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v5
+            - name: Build Docker image
+              run: docker build .

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -9,7 +9,6 @@ import type {
     PlayerUpdatePayload
 } from "./types.js";
 
-
 export interface GatewayPayload {
     op: number;
     d: unknown;

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,12 +1,9 @@
 export type { GatewayPayload, LinkDaveClientOptions, LinkDaveManagerEvents, SendToShardFn } from "./client.js";
 export { LinkDaveClient } from "./client.js";
-
 export type { NodeOptions, NodeState } from "./node.js";
 export { Node } from "./node.js";
-
 export type { PlayerOptions, PlayOptions, RawVoiceServerUpdate, RawVoiceStateUpdate } from "./player.js";
 export { Player } from "./player.js";
-
 export type {
     GuildPayload,
     IdentifyPayload,
@@ -33,7 +30,6 @@ export type {
     VoiceUpdatePayload,
     VolumePayload
 } from "./types.js";
-
 export {
     ClientOpCodes,
     ServerOpCodes

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -35,7 +35,6 @@ export interface Message<T = unknown> {
     d?: T;
 }
 
-
 export interface IdentifyPayload {
     bot_id: string;
 }


### PR DESCRIPTION
This commit introduces two new GitHub Actions workflows to automate testing for both the client and server packages.

The `test-client.yml` workflow runs on pull requests to the main branch and performs the following steps for the client package:
- Checks out the repository
- Sets up the Bun runtime
- Installs dependencies using a frozen lockfile
- Builds the client package
- Runs ESLint for linting

The `test-server.yml` workflow also triggers on pull requests to the main branch and builds a Docker image for the server package.

These workflows will help ensure code quality and prevent regressions by automatically running tests and linting on every pull request.