### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -18,28 +18,13 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Check if package version changed
-              id: check_publish
-              working-directory: ./client
-              run: |
-                  current_version=$(node -p "require('./package.json').version")
-                  npm_package_name=$(node -p "require('./package.json').name")
-                  published_version=$(npm show $npm_package_name version) || echo "0.0.0"
-
-                  echo "Current version: $current_version"
-                  echo "Published version: $published_version"
-
-                  if [ "$current_version" == "$published_version" ]; then
-                      echo "No new version. Skipping publish."
-                      echo "publish=false" >> $GITHUB_ENV
-                  else
-                      echo "New version available. Proceeding to publish."
-                      echo "publish=true" >> $GITHUB_ENV
-                  fi
-
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: "latest"
+
+            - name: Check if package version changed
+              id: check_publish
+              run: bun ./scripts/check-version.ts
 
             - run: bun install --frozen-lockfile
               working-directory: ./client

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -23,37 +23,19 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Set repository variables in lowercase
-              run: echo "REPOSITORY_OWNER=${OWNER,,}" >>${GITHUB_ENV}
-              env:
-                  OWNER: "${{ github.repository_owner }}"
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "latest"
 
             - name: Check if package version changed
               id: check_publish
-              working-directory: ./client
-              run: |
-                  current_version=$(node -p "require('./package.json').version")
-                  npm_package_name=$(node -p "require('./package.json').name")
-                  published_version=$(npm show $npm_package_name version) || echo "0.0.0"
-
-                  echo "Current version: $current_version"
-                  echo "Published version: $published_version"
-
-                  echo "version=$current_version" >> $GITHUB_ENV
-
-                  if [ "$current_version" == "$published_version" ]; then
-                      echo "No new version. Skipping publish."
-                      echo "publish=false" >> $GITHUB_ENV
-                  else
-                      echo "New version available. Proceeding to publish."
-                      echo "publish=true" >> $GITHUB_ENV
-                  fi
+              run: bun ./scripts/check-version.ts
 
             - name: Build Docker image
-              run: docker build --build-arg BUILD_VERSION=${{ env.version }} -t ghcr.io/${REPOSITORY_OWNER}/${{ github.event.repository.name }}:latest -t ghcr.io/${REPOSITORY_OWNER}/${{ github.event.repository.name }}:${{ env.version }} .
+              run: docker build --build-arg BUILD_VERSION=${{ env.version }} -t ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest -t ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ env.version }} .
 
             - name: Push Docker image
               if: env.publish == 'true'
               run: |
-                  docker push ghcr.io/${REPOSITORY_OWNER}/${{ github.event.repository.name }}:latest
-                  docker push ghcr.io/${REPOSITORY_OWNER}/${{ github.event.repository.name }}:${{ env.version }}
+                  docker push ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+                  docker push ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ env.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: release
+
+on:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        name: GitHub Release
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: "latest"
+
+            - name: Check if package version changed
+              id: check_publish
+              run: bun ./scripts/check-version.ts
+
+            - name: Generate Changelog
+              if: env.publish == 'true'
+              run: bun ./scripts/generate-changelog.ts
+
+            - name: Extract Server Binary
+              if: env.publish == 'true'
+              run: |
+                  docker build --target builder --build-arg BUILD_VERSION=${{ env.version }} -t linkdave-builder:release .
+                  docker create --name extract-release linkdave-builder:release
+                  docker cp extract-release:/app/linkdave ./linkdave-linux-amd64
+                  docker rm extract-release
+                  chmod +x ./linkdave-linux-amd64
+
+            - name: Create Tag and Release
+              if: env.publish == 'true'
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: "v${{ env.version }}"
+                  name: "v${{ env.version }}"
+                  body_path: "CHANGELOG.md"
+                  files: |
+                      linkdave-linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,10 @@ COPY go.mod go.sum* ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o linkdave ./cmd/linkdave
+
+ARG BUILD_VERSION
+ENV VERSION=$BUILD_VERSION
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" -o linkdave ./cmd/linkdave
 
 FROM debian:trixie-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,13 +43,9 @@ RUN go mod download
 COPY . .
 
 ARG BUILD_VERSION
-ENV VERSION=$BUILD_VERSION
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" -o linkdave ./cmd/linkdave
 
 FROM debian:trixie-slim
-
-ARG BUILD_VERSION
-ENV VERSION=$BUILD_VERSION
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/README.md
+++ b/README.md
@@ -21,10 +21,132 @@ If you need help using this, [join our Discord Server](https://discord.com/invit
 ### ⚙️ How the Server Works
 Linkdave consists of a Go-based audio server that manages Discord voice connections and playback.
 
-- **WebSocket (`/ws`):** Provides a persistent connection for real-time events. The server dispatches track updates (start, end, error), voice connection states, player updates, and node statistics.
-- **REST API:** Exposes endpoints to control playback operations such as Play, Pause, Resume, Stop, ~~Seek, and Volume~~ adjustments.
+- **WebSocket (`/ws`):** Provides a persistent connection for real-time events.
+- **REST API:** Exposes endpoints to control playback operations.
 
 The server leverages custom audio processing to directly pipeline from an audio source into Discord's UDP socket for low-latency streaming without relying on external bloat.
+
+#### Docker Deployment
+To deploy Linkdave using Docker, you can use the following `compose.yml` configuration. This setup exposes the WebSocket API on port 8080 and includes health checks to ensure the service is running properly.
+
+`compose.yml`:
+```yml
+services:
+    linkdave:
+        image: ghcr.io/shi-gg/linkdave:latest
+        container_name: radio-linkdave
+        restart: unless-stopped
+        ports:
+            - "8080:8080"
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+            interval: 30s
+            timeout: 3s
+            start_period: 5s
+            retries: 3
+        logging:
+            driver: json-file
+            options:
+                max-size: "10m"
+                max-file: "3"
+        environment:
+            LINKDAVE_SOURCE_HTTPS_ENABLED: true
+            LINKDAVE_SOURCE_IP_ADDRESS_PUBLIC_ENABLED: true
+```
+
+To start the server, run:
+```bash
+docker compose up -d
+```
+
+To update the server, simply pull the latest image and restart the container:
+```bash
+docker pull ghcr.io/shi-gg/linkdave:latest
+docker compose restart linkdave
+```
+
+#### Binary Deployment
+Alternatively, you can download the latest binary release from the [GitHub Releases page](https://github.com/shi-gg/linkdave/releases) and run it directly on your server.
+
+> [!CAUTION]
+> Linkdave relies on a C library, `libdave.so` from [discord/libdave](https://github.com/discord/libdave), for [Discord Audio E2EE](https://daveprotocol.com). This library is included in the Docker image, but not the binary.
+
+When using the standalone `linkdave-linux-amd64` binary, the system needs to know where to find the `libdave.so` shared library. Without it, the application will fail to launch, and running `ldd linkdave-linux-amd64` will report `libdave.so => not found`.
+
+To download the library, go to the [libdave releases page](https://github.com/discord/libdave/releases) and download the `libdave-Linux-X64-boringssl.zip` asset. Extract the `lib/libdave.so` file and follow one of the installation methods below.
+
+<details>
+
+<summary>Installing the `libdave.so` library</summary>
+
+Choose one of the methods below based on your OS and whether you want a system-wide or portable installation.
+
+##### Method 1: System-Wide Installation (Recommended)
+Installing the library system-wide allows you to run `linkdave-linux-amd64` from anywhere without needing to set environment variables.
+
+###### Ubuntu / Debian
+On Ubuntu and Debian systems, the standard directory for local 64-bit shared libraries is `/usr/local/lib`.
+
+```bash
+# 1. Copy the library to the standard path
+sudo cp libdave.so /usr/local/lib/
+
+# 2. Update the dynamic linker cache
+sudo ldconfig
+
+# 3. Make the binary executable
+chmod +x ./linkdave-linux-amd64
+
+# 4. Verify the library is found (it should map to /usr/local/lib/libdave.so)
+ldd ./linkdave-linux-amd64 | grep libdave
+```
+
+###### RHEL / Fedora / CentOS
+On Red Hat-based systems, 64-bit libraries belong in `/usr/local/lib64`.
+Depending on your system configuration, you might also need to explicitly add this directory to the linker's search path.
+
+```bash
+# 1. Create the directory (if it doesn't exist) and copy the library
+sudo mkdir -p /usr/local/lib64
+sudo cp libdave.so /usr/local/lib64/
+
+# 2. Ensure the directory is in the linker's search path
+echo "/usr/local/lib64" | sudo tee /etc/ld.so.conf.d/local64.conf
+
+# 3. Update the dynamic linker cache
+sudo ldconfig
+
+# 4. Make the binary executable
+chmod +x ./linkdave-linux-amd64
+
+# 5. Verify the library is found (it should map to /usr/local/lib64/libdave.so)
+ldd ./linkdave-linux-amd64 | grep libdave
+```
+
+---
+
+##### Method 2: Portable Setup (No Root Required)
+If you do not have `sudo` access or prefer to keep the binary and library together in a self-contained folder, you can run the binary by explicitly passing the library path at runtime.
+
+Ensure `libdave.so` and `linkdave-linux-amd64` are in the same folder.
+
+```bash
+# 1. Make the binary executable
+chmod +x ./linkdave-linux-amd64
+
+# 2. Run the binary with LD_LIBRARY_PATH set to the current directory
+LD_LIBRARY_PATH=. ./linkdave-linux-amd64
+```
+
+---
+
+##### Run the binary
+
+```bash
+LINKDAVE_SOURCE_HTTPS_ENABLED=true LINKDAVE_SOURCE_IP_ADDRESS_PUBLIC_ENABLED=true ./linkdave-linux-amd64
+```
+
+</details>
 
 ### 💻 Using the Client Library (TypeScript)
 Linkdave provides a robust, fully type-safe, TypeScript client for seamless interaction.
@@ -35,7 +157,8 @@ There is a quick example bot inside the [`example/`](https://github.com/shi-gg/l
 import { Client, GatewayIntentBits, Events } from "discord.js";
 import { LinkDaveClient, EventName } from "linkdave";
 
-const discord = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates] });
+// `GatewayIntentBits.GuildVoiceStates` is required!
+const discord = new Client({ intents: [GatewayIntentBits.GuildVoiceStates] });
 
 const linkdave = new LinkDaveClient({
     token: process.env.DISCORD_TOKEN,
@@ -76,8 +199,4 @@ Linkdave is built for high availability. When a server node needs to shut down (
 4. **Playback Resumes:** Once the new node takes over the voice UDP connection, playback resumes transparently.
 5. **Zero Downtime:** The draining server waits until its tracked player count drops to zero (or hits a 30-second hard timeout deadline) before fully powering off, ensuring no track is ever forcefully interrupted.
 
-The gap between closing the UDP connection on the old node and sending the first opus frame from the new node is typically under 500ms, providing a near-seamless experience for listeners.
-
-One test migration log from a local test run:
-- `13:05:00.785138722`: voice gateway close received;
-- `13:05:01.241348505`: sending voice gateway command;
+The gap between closing the UDP connection on the old node and sending the first opus frame from the new node is under 500ms, providing a near-seamless experience for listeners.

--- a/cmd/linkdave/main.go
+++ b/cmd/linkdave/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/shi-gg/linkdave/server/audio"
 	"github.com/shi-gg/linkdave/server/server"
 	"github.com/shi-gg/linkdave/server/voice"
 )
@@ -18,7 +19,7 @@ const (
 	DRAIN_TIMEOUT_SEC = 30 // Time to wait for players to migrate before force shutdown
 )
 
-var version = os.Getenv("VERSION")
+var version = ""
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -30,8 +31,9 @@ func main() {
 		slog.String("version", version),
 	)
 
+	audio.SetVersion(version)
 	voiceManager := voice.NewManager(logger)
-	server := server.NewServer(logger, voiceManager)
+	server := server.NewServer(logger, voiceManager, version)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", server.HandleWebSocket)

--- a/example/index.ts
+++ b/example/index.ts
@@ -19,7 +19,7 @@ const discord = new Client({
 const linkdave = new LinkDaveClient({
     token: DISCORD_TOKEN,
     nodes: [
-        { name: "main", url: "ws://localhost:8080" },
+        { name: "main", url: "ws://localhost:18080" },
         // { name: "sec", url: "ws://localhost:18090" }
     ],
     sendToShard: (guildId, payload) => {

--- a/example/index.ts
+++ b/example/index.ts
@@ -19,7 +19,7 @@ const discord = new Client({
 const linkdave = new LinkDaveClient({
     token: DISCORD_TOKEN,
     nodes: [
-        { name: "main", url: "ws://localhost:18080" },
+        { name: "main", url: "ws://localhost:8080" },
         // { name: "sec", url: "ws://localhost:18090" }
     ],
     sendToShard: (guildId, payload) => {

--- a/scripts/check-version.ts
+++ b/scripts/check-version.ts
@@ -1,0 +1,33 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGE_PATH = join(import.meta.dirname, "..", "client", "package.json");
+const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, "utf-8"));
+
+const VERSION = packageJson.version;
+const PACKAGE_NAME = packageJson.name;
+
+let publishedVersion = "0.0.0";
+try {
+    publishedVersion = execSync(`npm show ${PACKAGE_NAME} version`, {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "ignore"]
+    }).trim();
+} catch { }
+
+console.log(`Current version:  ${VERSION}`);
+console.log(`Published version: ${publishedVersion}`);
+
+const shouldPublish = VERSION !== publishedVersion;
+
+if (shouldPublish) {
+    console.log("New version available: " + VERSION);
+} else {
+    console.log("No new version.");
+}
+
+const githubEnv = process.env.GITHUB_ENV;
+if (githubEnv) {
+    writeFileSync(githubEnv, `version=${VERSION}\npublish=${shouldPublish}\n`, { flag: "a" });
+}

--- a/scripts/check-version.ts
+++ b/scripts/check-version.ts
@@ -14,7 +14,9 @@ try {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "ignore"]
     }).trim();
-} catch { }
+} catch {
+    console.warn(`Could not get published version for '${PACKAGE_NAME}'.`);
+}
 
 console.log(`Current version:  ${VERSION}`);
 console.log(`Published version: ${publishedVersion}`);

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,0 +1,100 @@
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CONVENTIONAL_COMMIT_REGEX = /^(feat|perf|fix|refactor|docs|build|types|chore|examples|test|style|ci)(?:\(([^()]+)\))?!?: (.+)$/i;
+const STRIP_GIT_REGEX = /\.git$/;
+const PR_REGEX = /\(#(\d+)\)$/;
+const SPACE_PR_REGEX = /\s*\(#\d+\)$/;
+
+const PACKAGE_PATH = join(import.meta.dirname, "..", "client", "package.json");
+const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, "utf-8"));
+const VERSION = packageJson.version;
+const TAG = `v${VERSION}`;
+
+function run(cmd: string) {
+    try {
+        return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] }).trim();
+    } catch {
+        return "";
+    }
+}
+
+const REMOTE_URL = run("git config --get remote.origin.url").replace(STRIP_GIT_REGEX, "");
+const PREV_TAG = run("git describe --tags --abbrev=0");
+
+const log = run(
+    PREV_TAG
+        ? `git log ${PREV_TAG}..HEAD --pretty=format:"%H|%h|%s"`
+        : "git log --pretty=format:\"%H|%h|%s\""
+);
+
+const commits = log
+    .split("\n")
+    .filter(Boolean);
+
+const categories: Record<string, { title: string; items: string[]; }> = {
+    feat: { title: "🚀 Features", items: [] },
+    perf: { title: "🔥 Performance", items: [] },
+    fix: { title: "🩹 Fixes", items: [] },
+    refactor: { title: "💅 Refactors", items: [] },
+    docs: { title: "📖 Documentation", items: [] },
+    build: { title: "📦 Build", items: [] },
+    chore: { title: "🏡 Chore", items: [] },
+    test: { title: "✅ Tests", items: [] },
+    style: { title: "🎨 Styles", items: [] },
+    ci: { title: "🤖 CI", items: [] },
+    other: { title: "🛸 Other", items: [] }
+};
+
+for (const line of commits) {
+    const [fullHash, shortHash, ...subjectParts] = line.split("|");
+    const subject = subjectParts.join("|");
+
+    const prNumber = subject.match(PR_REGEX)?.[1];
+    const msg = prNumber ? subject.replace(SPACE_PR_REGEX, "") : subject;
+    const prLink = prNumber
+        ? ` ([#${prNumber}](${REMOTE_URL}/pull/${prNumber}))`
+        : ` ([${shortHash}](${REMOTE_URL}/commit/${fullHash}))`;
+
+    const parts = msg.match(CONVENTIONAL_COMMIT_REGEX);
+
+    if (!parts) {
+        const description = msg.charAt(0).toUpperCase() + msg.slice(1);
+        categories.other.items.push(`- ${description}${prLink}`);
+
+        continue;
+    }
+
+    const type = parts[1].toLowerCase();
+    const scope = parts[2];
+    const description = parts[3]
+        .charAt(0)
+        .toUpperCase()
+        + parts[3].slice(1);
+
+    const formattedMsg = scope
+        ? `- **${categories[type] ? "" : `${type}: `}${scope}:** ${description}${prLink}`
+        : `- ${categories[type] ? "" : `${type}: `}${description}${prLink}`;
+
+    if (categories[type]) categories[type].items.push(formattedMsg);
+    else categories.other.items.push(formattedMsg);
+
+}
+
+let changelog = "";
+if (PREV_TAG) changelog += `[compare changes](${REMOTE_URL}/compare/${PREV_TAG}...${TAG})\n\n`;
+else changelog += `[compare changes](${REMOTE_URL}/commits/${TAG})\n\n`;
+
+for (const key of Object.keys(categories)) {
+    const category = categories[key];
+    if (category.items.length > 0) {
+        changelog += `${category.title}\n\n`;
+        changelog += category.items.join("\n") + "\n\n";
+    }
+}
+
+const finalChangelog = changelog.trim() + "\n";
+writeFileSync("CHANGELOG.md", finalChangelog);
+
+console.log(finalChangelog);

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -21,7 +21,7 @@ function run(cmd: string) {
 }
 
 const REMOTE_URL = run("git config --get remote.origin.url").replace(STRIP_GIT_REGEX, "");
-const PREV_TAG = run("git describe --tags --abbrev=0");
+const PREV_TAG = run("git describe --tags --abbrev=0 || echo ''");
 
 const log = run(
     PREV_TAG

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -89,7 +89,7 @@ else changelog += `[compare changes](${REMOTE_URL}/commits/${TAG})\n\n`;
 for (const key of Object.keys(categories)) {
     const category = categories[key];
     if (category.items.length > 0) {
-        changelog += `${category.title}\n\n`;
+        changelog += `### ${category.title}\n\n`;
         changelog += category.items.join("\n") + "\n\n";
     }
 }

--- a/server/audio/config.go
+++ b/server/audio/config.go
@@ -25,8 +25,11 @@ func init() {
 		PrivateIPAddressEnabled: getEnvBool("LINKDAVE_SOURCE_IP_ADDRESS_PRIVATE_ENABLED", false),
 		TextToSpeechEnabled:     getEnvBool("LINKDAVE_SOURCE_TEXT_TO_SPEECH_ENABLED", false),
 		TextToSpeechURL:         getEnvString("LINKDAVE_SOURCE_TEXT_TO_SPEECH_URL", "https://tts.wamellow.com/api/invoke"),
-		UserAgent:               "Linkdave/" + os.Getenv("VERSION"),
 	}
+}
+
+func SetVersion(v string) {
+	config.UserAgent = "Linkdave/" + v
 }
 
 func GetConfig() SourceConfig {

--- a/server/server/routes.go
+++ b/server/server/routes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -14,10 +13,7 @@ import (
 	"github.com/shi-gg/linkdave/server/protocol"
 )
 
-var (
-	version   = os.Getenv("VERSION")
-	startTime = time.Now()
-)
+var startTime = time.Now()
 
 func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/health", s.routeHealth)
@@ -70,7 +66,7 @@ func (s *Server) routeStats(w http.ResponseWriter, _ *http.Request) {
 	runtime.ReadMemStats(&memStats)
 
 	response := protocol.StatsResponse{
-		Version:      version,
+		Version:      s.version,
 		Runtime:      runtime.Version(),
 		Uptime:       time.Since(startTime).Milliseconds(),
 		NumGoroutine: runtime.NumGoroutine(),

--- a/server/server/websocket.go
+++ b/server/server/websocket.go
@@ -32,14 +32,16 @@ type Server struct {
 	startTime    time.Time
 	draining     bool
 	drainMu      sync.RWMutex
+	version      string
 }
 
-func NewServer(logger *slog.Logger, voiceManager *voice.Manager) *Server {
+func NewServer(logger *slog.Logger, voiceManager *voice.Manager, version string) *Server {
 	s := &Server{
 		logger:       logger,
 		voiceManager: voiceManager,
 		clients:      make(map[string]*Client),
 		startTime:    time.Now(),
+		version:      version,
 	}
 	voiceManager.SetEventHandler(s)
 	s.startTickers()


### PR DESCRIPTION
Replace inline bash version checks with a TypeScript script, update Dockerfile to use build args for versioning, and add a new GitHub workflow for automated releases with changelog generation.