### PR TITLE
fix: prevent cascading failures on voice gateway disconnect

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -169,7 +169,7 @@ export class LinkDaveClient extends EventEmitter {
                 if (data.user_id !== this.#clientId) return;
 
                 const player = this.#players.get(data.guild_id);
-                player?.handleVoiceStateUpdate({
+                void player?.handleVoiceStateUpdate({
                     user_id: data.user_id,
                     channel_id: data.channel_id,
                     session_id: data.session_id
@@ -179,7 +179,7 @@ export class LinkDaveClient extends EventEmitter {
             }
             case GatewayDispatchEvents.VoiceServerUpdate: {
                 const player = this.#players.get(data.guild_id);
-                player?.handleVoiceServerUpdate(data);
+                void player?.handleVoiceServerUpdate(data);
 
                 break;
             }

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -161,7 +161,7 @@ export class LinkDaveClient extends EventEmitter {
         return this.#clientId;
     }
 
-    async handleRaw({ t: event, d: data }: GatewayDispatchPayload) {
+    handleRaw({ t: event, d: data }: GatewayDispatchPayload) {
         switch (event) {
             case GatewayDispatchEvents.VoiceStateUpdate: {
                 // https://discord.com/developers/docs/resources/voice#voice-state-object
@@ -169,7 +169,7 @@ export class LinkDaveClient extends EventEmitter {
                 if (data.user_id !== this.#clientId) return;
 
                 const player = this.#players.get(data.guild_id);
-                await player?.handleVoiceStateUpdate({
+                player?.handleVoiceStateUpdate({
                     user_id: data.user_id,
                     channel_id: data.channel_id,
                     session_id: data.session_id
@@ -179,7 +179,7 @@ export class LinkDaveClient extends EventEmitter {
             }
             case GatewayDispatchEvents.VoiceServerUpdate: {
                 const player = this.#players.get(data.guild_id);
-                await player?.handleVoiceServerUpdate(data);
+                player?.handleVoiceServerUpdate(data);
 
                 break;
             }

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -208,9 +208,6 @@ export class Player {
         this.#tryConnectLinkDave();
     }
 
-    // A null endpoint means that the voice server allocated has gone away and is trying to be reallocated.
-    // You should attempt to disconnect from the currently connected voice server,
-    // and not attempt to reconnect until a new voice server is allocated.
     async handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
         if (!data.endpoint) {
             const hadVoiceState = this.#voiceState !== null;
@@ -221,8 +218,6 @@ export class Player {
             }
 
             // Only send disconnect if we had an active voice state to tear down.
-            // Fire-and-forget: don't await, so a subsequent valid VOICE_SERVER_UPDATE
-            // isn't delayed by the HTTP round-trip.
             if (hadVoiceState && this.#node.connected) {
                 const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
                 if (err) this.#node.emit(EventName.Error, err as Error);

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -180,7 +180,7 @@ export class Player {
         this.#lastServerEvent = null;
     }
 
-    handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
+    async handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
         if (!data.channel_id) {
             this.#voiceChannelId = null;
             this.#voiceState = null;
@@ -188,7 +188,8 @@ export class Player {
             this.#lastServerEvent = null;
 
             if (this.#node.connected) {
-                void unwrap(this.#node.sendDisconnect(this.#guildId));
+                const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
+                if (err) this.#node.emit(EventName.Error, err as Error);
             }
 
             return;
@@ -210,7 +211,7 @@ export class Player {
     // A null endpoint means that the voice server allocated has gone away and is trying to be reallocated.
     // You should attempt to disconnect from the currently connected voice server,
     // and not attempt to reconnect until a new voice server is allocated.
-    handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
+    async handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
         if (!data.endpoint) {
             const hadVoiceState = this.#voiceState !== null;
             this.#voiceState = null;
@@ -223,7 +224,8 @@ export class Player {
             // Fire-and-forget: don't await, so a subsequent valid VOICE_SERVER_UPDATE
             // isn't delayed by the HTTP round-trip.
             if (hadVoiceState && this.#node.connected) {
-                void unwrap(this.#node.sendDisconnect(this.#guildId));
+                const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
+                if (err) this.#node.emit(EventName.Error, err as Error);
             }
 
             return;

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -7,6 +7,7 @@ import type {
     PlayerUpdatePayload,
     TrackInfo,
     VoiceConnectPayload,
+    VoiceDisconnectPayload,
     VoiceServerEvent
 } from "./types.js";
 import { EventName, PlayerState } from "./types.js";
@@ -126,9 +127,17 @@ export class Player {
         });
 
         return new Promise<VoiceConnectPayload>((resolve, reject) => {
+            const cleanup = () => {
+                this.#node.off(EventName.VoiceConnect, onConnect);
+                this.#node.off(EventName.VoiceDisconnect, onDisconnect);
+                clearTimeout(timer);
+            };
+
             const timer = setTimeout(
                 () => {
-                    this.#node.off(EventName.VoiceConnect, onConnect);
+                    cleanup();
+                    this.#pendingVoice = null;
+                    this.#lastServerEvent = null;
                     reject(new Error(`Voice connection timed out for guild "${this.#guildId}"`));
                 },
                 timeoutMs
@@ -136,12 +145,18 @@ export class Player {
 
             const onConnect = (event: VoiceConnectPayload) => {
                 if (event.guild_id !== this.#guildId) return;
-                this.#node.off(EventName.VoiceConnect, onConnect);
-                clearTimeout(timer);
+                cleanup();
                 resolve(event);
             };
 
+            const onDisconnect = (event: VoiceDisconnectPayload) => {
+                if (event.guild_id !== this.#guildId) return;
+                cleanup();
+                reject(new Error(`Voice connection failed for guild "${this.#guildId}": ${event.reason ?? "unknown"}`));
+            };
+
             this.#node.on(EventName.VoiceConnect, onConnect);
+            this.#node.on(EventName.VoiceDisconnect, onDisconnect);
         });
     }
 
@@ -165,7 +180,7 @@ export class Player {
         this.#lastServerEvent = null;
     }
 
-    async handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
+    handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
         if (!data.channel_id) {
             this.#voiceChannelId = null;
             this.#voiceState = null;
@@ -173,7 +188,7 @@ export class Player {
             this.#lastServerEvent = null;
 
             if (this.#node.connected) {
-                await unwrap(this.#node.sendDisconnect(this.#guildId));
+                void unwrap(this.#node.sendDisconnect(this.#guildId));
             }
 
             return;
@@ -195,16 +210,20 @@ export class Player {
     // A null endpoint means that the voice server allocated has gone away and is trying to be reallocated.
     // You should attempt to disconnect from the currently connected voice server,
     // and not attempt to reconnect until a new voice server is allocated.
-    async handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
+    handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
         if (!data.endpoint) {
+            const hadVoiceState = this.#voiceState !== null;
             this.#voiceState = null;
 
             if (this.#pendingVoice) {
                 delete this.#pendingVoice.serverEvent;
             }
 
-            if (this.#node.connected) {
-                await unwrap(this.#node.sendDisconnect(this.#guildId));
+            // Only send disconnect if we had an active voice state to tear down.
+            // Fire-and-forget: don't await, so a subsequent valid VOICE_SERVER_UPDATE
+            // isn't delayed by the HTTP round-trip.
+            if (hadVoiceState && this.#node.connected) {
+                void unwrap(this.#node.sendDisconnect(this.#guildId));
             }
 
             return;


### PR DESCRIPTION
- guard sendDisconnect on null endpoint to skip if voice state already cleared
- make voice event handlers fire-and-forget to avoid yielding during reconnect
- reject connect() promise on VoiceDisconnect instead of hanging until timeout
- clear stale voice credentials on connect() timeout