### PR TITLE
fix: bot channel move

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -210,10 +210,7 @@ export class Player {
         this.#pendingVoice.channelId = data.channel_id;
         this.#pendingVoice.sessionId = data.session_id;
 
-        // If we already have a server event from a previous connection to the same
-        // channel and no new VOICE_SERVER_UPDATE has been received yet, re-use it.
-        const isSameChannelReconnect = this.#voiceState?.channelId === data.channel_id;
-        if (!this.#pendingVoice.serverEvent && this.#lastServerEvent && isSameChannelReconnect) {
+        if (!this.#pendingVoice.serverEvent && this.#lastServerEvent && this.#voiceState?.channelId === data.channel_id) {
             this.#pendingVoice.serverEvent = this.#lastServerEvent;
         }
 

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -212,7 +212,8 @@ export class Player {
 
         // If we already have a server event from a previous connection to the same
         // channel and no new VOICE_SERVER_UPDATE has been received yet, re-use it.
-        if (!this.#pendingVoice.serverEvent && this.#lastServerEvent) {
+        const isSameChannelReconnect = this.#voiceState?.channelId === data.channel_id;
+        if (!this.#pendingVoice.serverEvent && this.#lastServerEvent && isSameChannelReconnect) {
             this.#pendingVoice.serverEvent = this.#lastServerEvent;
         }
 


### PR DESCRIPTION
only reuse voice server event on same channel reconnect