### PR TITLE
fix: clear voiceChannelId and deactivate queue on voice disconnect

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -375,6 +375,8 @@ export class Player {
     }
 
     _onVoiceDisconnect() {
+        this.#voiceChannelId = null;
+        this.#queue._deactivate();
         this.#voiceState = null;
         this.#pendingVoice = null;
         this.#state = PlayerState.Idle;


### PR DESCRIPTION
Fixes #43

## Summary

When the voice gateway disconnects and `_onVoiceDisconnect` is called, `#voiceChannelId` was not being cleared and `#queue` was not being deactivated. This created an inconsistent state compared to the user-initiated `disconnect()` method.

## Changes

- Clear `#voiceChannelId` on voice disconnect (consistent with `disconnect()`)
- Deactivate `#queue` to prevent phantom track playback attempts

This prevents:
1. `player.voiceChannelId` returning stale channel IDs after disconnect
2. `player.queue.active` remaining `true`, which caused the queue to burn through remaining tracks with connection errors