### PR TITLE
fix: extract cleanup for full reset on all disconnect paths

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -168,8 +168,6 @@ export class Player {
     }
 
     disconnect() {
-        this.#queue._deactivate();
-
         this.#client._sendToShard(this.#guildId, {
             op: GatewayOpcodes.VoiceStateUpdate,
             d: {
@@ -180,12 +178,7 @@ export class Player {
             }
         });
 
-        this.#voiceChannelId = null;
-        this.#state = PlayerState.Idle;
-        this.#current = null;
-        this.#position = 0;
-        this.#voiceState = null;
-        this.#pendingVoice = null;
+        this.#cleanup();
     }
 
     async handleVoiceStateUpdate(data: RawVoiceStateUpdate) {

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -190,9 +190,7 @@ export class Player {
 
     async handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
         if (!data.channel_id) {
-            this.#voiceChannelId = null;
-            this.#voiceState = null;
-            this.#pendingVoice = null;
+            this.#cleanup();
 
             if (this.#node.connected) {
                 const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
@@ -212,13 +210,8 @@ export class Player {
     async handleVoiceServerUpdate(data: RawVoiceServerUpdate) {
         if (!data.endpoint) {
             const hadVoiceState = this.#voiceState !== null;
-            this.#voiceState = null;
+            this.#cleanup();
 
-            if (this.#pendingVoice) {
-                delete this.#pendingVoice.serverEvent;
-            }
-
-            // Only send disconnect if we had an active voice state to tear down.
             if (hadVoiceState && this.#node.connected) {
                 const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
                 if (err) this.#node.emit(EventName.Error, err as Error);
@@ -374,7 +367,7 @@ export class Player {
         this.#queue._onTrackEnd(data.reason !== TrackEndReason.Stopped);
     }
 
-    _onVoiceDisconnect() {
+    #cleanup() {
         this.#voiceChannelId = null;
         this.#queue._deactivate();
         this.#voiceState = null;
@@ -382,6 +375,10 @@ export class Player {
         this.#state = PlayerState.Idle;
         this.#current = null;
         this.#position = 0;
+    }
+
+    _onVoiceDisconnect() {
+        this.#cleanup();
     }
 
     _onMigrateReady(data: MigrateReadyPayload) {


### PR DESCRIPTION
Extract a reusable #cleanup() private method that fully resets player state (clears voiceChannelId, deactivates queue, resets state/position/ current). Use it in all three disconnect entry points:

- _onVoiceDisconnect() — node-triggered disconnect
- handleVoiceStateUpdate(null) — Discord gateway echo (bot kicked/left VC)
- handleVoiceServerUpdate(null) — voice server lost

Previously, handleVoiceStateUpdate(null) and handleVoiceServerUpdate(null) only partially cleaned state, leaving #queue active and #state/#current stale if the node never responded with VoiceDisconnect. Now the player is always in a consistent state regardless of node response.

Refs #43