### PR TITLE
fix: voice disconnect reconnect cascade

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -171,24 +171,18 @@ export class LinkDaveClient extends EventEmitter {
                 if (data.user_id !== this.#clientId) return;
 
                 const player = this.#players.get(data.guild_id);
-                if (!player) {
-                    break;
-                }
 
-                void player.handleVoiceStateUpdate({
+                void player?.handleVoiceStateUpdate({
                     user_id: data.user_id,
                     channel_id: data.channel_id,
                     session_id: data.session_id
                 });
+
                 break;
             }
             case GatewayDispatchEvents.VoiceServerUpdate: {
                 const player = this.#players.get(data.guild_id);
-                if (!player) {
-                    break;
-                }
-
-                void player.handleVoiceServerUpdate(data);
+                void player?.handleVoiceServerUpdate(data);
                 break;
             }
         }
@@ -271,16 +265,12 @@ export class LinkDaveClient extends EventEmitter {
     }
 
     #handleConnectionLost(player: Player) {
-        const channelId = player.voiceChannelId;
-
-        if (channelId) {
-            player.disconnect();
-        } else {
-            player._onVoiceDisconnect();
-        }
+        if (player.voiceChannelId) player.disconnect();
+        else player._onVoiceDisconnect();
 
         player.node.decrementPlayerCount();
         this.#players.delete(player.guildId);
+
         this.emit(EventName.VoiceDisconnect, {
             guild_id: player.guildId,
             reason: DisconnectReason.ConnectionLost

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -16,6 +16,7 @@ import type {
     VoiceDisconnectPayload
 } from "./types.js";
 import {
+    DisconnectReason,
     EventName,
     ManagerEventName
 } from "./types.js";
@@ -166,23 +167,28 @@ export class LinkDaveClient extends EventEmitter {
     handleRaw({ t: event, d: data }: GatewayDispatchPayload) {
         switch (event) {
             case GatewayDispatchEvents.VoiceStateUpdate: {
-                // https://discord.com/developers/docs/resources/voice#voice-state-object
                 if (!data.guild_id) return;
                 if (data.user_id !== this.#clientId) return;
 
                 const player = this.#players.get(data.guild_id);
-                void player?.handleVoiceStateUpdate({
+                if (!player) {
+                    break;
+                }
+
+                void player.handleVoiceStateUpdate({
                     user_id: data.user_id,
                     channel_id: data.channel_id,
                     session_id: data.session_id
                 });
-
                 break;
             }
             case GatewayDispatchEvents.VoiceServerUpdate: {
                 const player = this.#players.get(data.guild_id);
-                void player?.handleVoiceServerUpdate(data);
+                if (!player) {
+                    break;
+                }
 
+                void player.handleVoiceServerUpdate(data);
                 break;
             }
         }
@@ -253,10 +259,32 @@ export class LinkDaveClient extends EventEmitter {
         const player = this.#players.get(data.guild_id);
         if (player?.node !== node) return;
 
+        if (data.reason === DisconnectReason.ConnectionLost) {
+            this.#handleConnectionLost(player);
+            return;
+        }
+
         player._onVoiceDisconnect();
-        this.emit(EventName.VoiceDisconnect, data);
         player.node.decrementPlayerCount();
         this.#players.delete(data.guild_id);
+        this.emit(EventName.VoiceDisconnect, data);
+    }
+
+    #handleConnectionLost(player: Player) {
+        const channelId = player.voiceChannelId;
+
+        if (channelId) {
+            player.disconnect();
+        } else {
+            player._onVoiceDisconnect();
+        }
+
+        player.node.decrementPlayerCount();
+        this.#players.delete(player.guildId);
+        this.emit(EventName.VoiceDisconnect, {
+            guild_id: player.guildId,
+            reason: DisconnectReason.ConnectionLost
+        });
     }
 
     _onPlayerDestroy(guildId: string) {

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -13,7 +13,7 @@ import type {
     VoiceDisconnectPayload,
     VoiceServerEvent
 } from "./types.js";
-import { EventName, PlayerState, TrackEndReason } from "./types.js";
+import { DisconnectReason, EventName, PlayerState, TrackEndReason } from "./types.js";
 import { unwrap } from "./utils.js";
 
 export interface PlayOptions {
@@ -123,6 +123,7 @@ export class Player {
         }
 
         this.#voiceChannelId = targetChannel;
+        this.#state = PlayerState.Connecting;
 
         this.#client._sendToShard(this.#guildId, {
             op: GatewayOpcodes.VoiceStateUpdate,
@@ -136,6 +137,9 @@ export class Player {
 
         return new Promise<VoiceConnectPayload>((resolve, reject) => {
             const cleanup = () => {
+                if (this.#state === PlayerState.Connecting) {
+                    this.#state = PlayerState.Idle;
+                }
                 this.#node.off(EventName.VoiceConnect, onConnect);
                 this.#node.off(EventName.VoiceDisconnect, onDisconnect);
                 clearTimeout(timer);
@@ -158,6 +162,7 @@ export class Player {
 
             const onDisconnect = (event: VoiceDisconnectPayload) => {
                 if (event.guild_id !== this.#guildId) return;
+                if (event.reason === DisconnectReason.Requested) return;
                 cleanup();
                 reject(new Error(`Voice connection failed for guild "${this.#guildId}": ${event.reason ?? "unknown"}`));
             };
@@ -183,9 +188,10 @@ export class Player {
 
     async handleVoiceStateUpdate(data: RawVoiceStateUpdate) {
         if (!data.channel_id) {
+            const hadVoiceState = this.#voiceState !== null;
             this.#cleanup();
 
-            if (this.#node.connected) {
+            if (hadVoiceState && this.#node.connected) {
                 const [, err] = await unwrap(this.#node.sendDisconnect(this.#guildId));
                 if (err) this.#node.emit(EventName.Error, err as Error);
             }
@@ -233,7 +239,6 @@ export class Player {
             return;
         }
 
-        // We have all the data, connect to LinkDave
         this.#connectToLinkDave(pending.channelId, pending.sessionId, pending.serverEvent);
         this.#pendingVoice = null;
     }
@@ -299,10 +304,8 @@ export class Player {
 
         const waitForVoiceDisconnect = this.#waitForNodeVoiceDisconnect(Player.CONNECT_TIMEOUT);
         await unwrap(this.#node.sendDisconnect(this.#guildId));
-
-        if (!(await waitForVoiceDisconnect)) {
-            this.#client._onPlayerDestroy(this.#guildId);
-        }
+        await waitForVoiceDisconnect;
+        this.#client._onPlayerDestroy(this.#guildId);
     }
 
     #waitForNodeVoiceDisconnect(timeoutMs: number) {

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -140,8 +140,10 @@ export class Player {
                 if (this.#state === PlayerState.Connecting) {
                     this.#state = PlayerState.Idle;
                 }
+
                 this.#node.off(EventName.VoiceConnect, onConnect);
                 this.#node.off(EventName.VoiceDisconnect, onDisconnect);
+
                 clearTimeout(timer);
             };
 
@@ -163,6 +165,7 @@ export class Player {
             const onDisconnect = (event: VoiceDisconnectPayload) => {
                 if (event.guild_id !== this.#guildId) return;
                 if (event.reason === DisconnectReason.Requested) return;
+
                 cleanup();
                 reject(new Error(`Voice connection failed for guild "${this.#guildId}": ${event.reason ?? "unknown"}`));
             };

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -30,7 +30,8 @@ export enum TrackEndReason {
 export enum PlayerState {
     Idle = "idle",
     Playing = "playing",
-    Paused = "paused"
+    Paused = "paused",
+    Connecting = "connecting"
 }
 
 export type ServerMessage =
@@ -124,6 +125,12 @@ export interface QueueErrorPayload {
     error: Error;
 }
 
+export enum DisconnectReason {
+    ConnectionLost = "connection_lost",
+    ConnectionFailed = "connection_failed",
+    Requested = "requested"
+}
+
 export interface VoiceConnectPayload {
     guild_id: string;
     channel_id: string;
@@ -131,7 +138,7 @@ export interface VoiceConnectPayload {
 
 export interface VoiceDisconnectPayload {
     guild_id: string;
-    reason?: string;
+    reason?: DisconnectReason;
 }
 
 export interface StatsPayload {

--- a/server/protocol/opcodes.go
+++ b/server/protocol/opcodes.go
@@ -32,3 +32,9 @@ const (
 	PlayerStatePlaying = "playing"
 	PlayerStatePaused  = "paused"
 )
+
+const (
+	DisconnectReasonConnectionLost   = "connection_lost"
+	DisconnectReasonConnectionFailed = "connection_failed"
+	DisconnectReasonRequested        = "requested"
+)

--- a/server/server/routes.go
+++ b/server/server/routes.go
@@ -310,7 +310,7 @@ func (s *Server) routeDisconnect(client *Client, guildID snowflake.ID, w http.Re
 		Op: protocol.OpVoiceDisconnect,
 		Data: protocol.VoiceDisconnectData{
 			GuildID: guildID,
-			Reason:  "requested",
+			Reason:  protocol.DisconnectReasonRequested,
 		},
 	})
 

--- a/server/server/websocket.go
+++ b/server/server/websocket.go
@@ -131,7 +131,7 @@ func (s *Server) OnVoiceDisconnected(sessionID string, guildID snowflake.ID) {
 		Op: protocol.OpVoiceDisconnect,
 		Data: protocol.VoiceDisconnectData{
 			GuildID: guildID,
-			Reason:  "connection_lost",
+			Reason:  protocol.DisconnectReasonConnectionLost,
 		},
 	})
 }
@@ -249,7 +249,7 @@ func (s *Server) handleVoiceUpdate(client *Client, data json.RawMessage) {
 			Op: protocol.OpVoiceDisconnect,
 			Data: protocol.VoiceDisconnectData{
 				GuildID: update.GuildID,
-				Reason:  "connection_failed",
+				Reason:  protocol.DisconnectReasonConnectionFailed,
 			},
 		})
 

--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -93,10 +93,26 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 	}
 
 	var currentVoiceConn voice.Conn
+	var sigVoiceConn voice.Conn
+
 	currentVoiceConn = voice.NewConn(
 		c.guildID,
 		c.userID,
 		func(ctx context.Context, guildID snowflake.ID, channelID *snowflake.ID, selfMute, selfDeaf bool) error {
+			if channelID != nil {
+				return nil
+			}
+
+			if vc := sigVoiceConn; vc != nil && !c.closed.Load() {
+				vc.HandleVoiceStateUpdate(gateway.EventVoiceStateUpdate{
+					VoiceState: discord.VoiceState{
+						GuildID:   guildID,
+						ChannelID: nil,
+						UserID:    c.userID,
+					},
+				})
+			}
+
 			return nil
 		},
 		func() {
@@ -107,21 +123,25 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 			}
 
 			c.mutex.Lock()
-			defer c.mutex.Unlock()
 			if c.targetVoiceConn != nil && c.voiceConn == currentVoiceConn {
+				c.mutex.Unlock()
 				return
 			}
 
 			isCurrent := c.voiceConn == currentVoiceConn
 			isTarget := c.targetVoiceConn == currentVoiceConn
+			c.mutex.Unlock()
 
 			if isCurrent || isTarget {
+				c.Stop()
 				c.onDisconnect()
 			}
 		},
 		voice.WithConnLogger(c.logger),
 		voice.WithConnDaveSessionCreateFunc(golibdave.NewSession),
 	)
+
+	sigVoiceConn = currentVoiceConn
 
 	c.mutex.Lock()
 	c.voiceConn = currentVoiceConn
@@ -284,7 +304,7 @@ func (c *Connection) Stop() {
 		c.source = nil
 		oldSource.Close()
 		if c.onTrackEnd != nil {
-			go c.onTrackEnd(oldSource, protocol.TrackEndReasonStopped, nil)
+			c.onTrackEnd(oldSource, protocol.TrackEndReasonStopped, nil)
 		}
 	}
 


### PR DESCRIPTION
When the voice gateway drops and resume returns 4006 (session no longer valid), the reconnect would fail because Discord does not re-send VoiceServerUpdate without a state change. The library also had ordering issues where the old player was deleted after the app handler created a new one (same guildId key).