### PR TITLE
fix: disconnect on channel move regression

### DIFF
--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -72,18 +72,9 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 	if c.setupCancel != nil {
 		c.setupCancel()
 	}
-	oldConn := c.voiceConn
 	c.voiceConn = nil
 	c.connectedUsers.Store(0)
 	c.mutex.Unlock()
-
-	if oldConn != nil {
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			defer cancel()
-			oldConn.Close(ctx)
-		}()
-	}
 
 	c.setupMu.Lock()
 	defer c.setupMu.Unlock()
@@ -118,7 +109,7 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 		func() {
 			c.logger.Debug("voice connection removed from manager")
 
-			if c.closed.Load() || c.onDisconnect == nil {
+			if c.closed.Load() {
 				return
 			}
 
@@ -128,13 +119,22 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 				return
 			}
 
-			isCurrent := c.voiceConn == currentVoiceConn
-			isTarget := c.targetVoiceConn == currentVoiceConn
+			vc := currentVoiceConn
+			isCurrent := c.voiceConn == vc
+			isTarget := c.targetVoiceConn == vc
 			c.mutex.Unlock()
 
-			if isCurrent || isTarget {
-				c.Stop()
-				c.onDisconnect()
+			if isCurrent {
+				c.safeSetOpusFrameProvider(vc, nil)
+				c.mutex.Lock()
+				if c.voiceConn == vc {
+					c.voiceConn = nil
+				}
+				c.mutex.Unlock()
+			} else if isTarget {
+				c.mutex.Lock()
+				c.targetVoiceConn = nil
+				c.mutex.Unlock()
 			}
 		},
 		voice.WithConnLogger(c.logger),


### PR DESCRIPTION
Fixes a regression introduced by #51 where removing the 5-second delay in `voiceStateUpdateFunc` caused `c.onDisconnect()` to fire during channel moves, cascading through `connection_lost` → `player.disconnect()` → `VoiceStateUpdate(null)` and kicking the bot from the new channel.

**Root cause:** the `removeConnFunc` callback treated voice gateway disconnects (4014/4022) as user-facing disconnect events, calling `c.Stop()` + `c.onDisconnect()`. These are actually Discord-driven session cleanup signals — the client manages connect/disconnect state explicitly via `OpVoiceUpdate`/`OpDisconnect`.

**Changes:**
- `removeConnFunc` no longer calls `c.onDisconnect()` — voice gateway disconnects are internal cleanup only
- Replaced `c.Stop()` (which destroys the audio source) with just detaching the opus frame provider — the source survives and transfers to the new connection via `setupVoiceConn`
- Removed the redundant `oldConn.Close()` goroutine — `handleGatewayClose` already handles cleanup, and calling `Close()` twice caused a "send on closed channel" panic
- The `voiceStateUpdateFunc` signal from #51 is preserved (avoids the 5s delay on gateway disconnect)