### PR TITLE
chore: remove dead ping/pong

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -13,6 +13,7 @@ import type {
     PlayerUpdatePayload,
     TrackEndPayload,
     TrackStartPayload,
+    VoiceConnectPayload,
     VoiceDisconnectPayload
 } from "./types.js";
 import {
@@ -195,15 +196,13 @@ export class LinkDaveClient extends EventEmitter {
     #setupNodeListeners(node: Node) {
         node.on(EventName.Ready, (data) => this.emit(EventName.Ready, data));
         node.on(EventName.PlayerUpdate, (data) => this.#handlePlayerUpdate(node, data));
-
         node.on(EventName.TrackStart, (data) => this.#handleTrackStart(node, data));
         node.on(EventName.TrackEnd, (data) => this.#handleTrackEnd(node, data));
         node.on(EventName.TrackError, (data) => this.#forwardPlayerEvent(node, data.guild_id, EventName.TrackError, data));
         node.on(EventName.QueueError, (data) => this.#forwardPlayerEvent(node, data.guild_id, EventName.QueueError, data));
-        node.on(EventName.VoiceConnect, (data) => this.#forwardPlayerEvent(node, data.guild_id, EventName.VoiceConnect, data));
+        node.on(EventName.VoiceConnect, (data) => this.#handleVoiceConnect(node, data));
         node.on(EventName.VoiceDisconnect, (data) => this.#handleVoiceDisconnect(node, data));
 
-        node.on(EventName.Pong, () => this.emit(EventName.Pong, undefined));
         node.on(EventName.Stats, (data) => this.emit(EventName.Stats, data));
 
         node.on(EventName.NodeDraining, (data) => this.#handleNodeDraining(node, data));
@@ -229,7 +228,7 @@ export class LinkDaveClient extends EventEmitter {
         const player = this.#players.get(data.guild_id);
         if (player?.node !== node) return;
 
-        player._updateState(data);
+        player._onPlayerUpdate(data);
         this.emit(EventName.PlayerUpdate, data);
     }
 
@@ -247,6 +246,14 @@ export class LinkDaveClient extends EventEmitter {
 
         player._onTrackEnd(data);
         this.emit(EventName.TrackEnd, data);
+    }
+
+    #handleVoiceConnect(node: Node, data: VoiceConnectPayload) {
+        const player = this.#players.get(data.guild_id);
+        if (player?.node !== node) return;
+
+        player._onVoiceConnect();
+        this.emit(EventName.VoiceConnect, data);
     }
 
     #handleVoiceDisconnect(node: Node, data: VoiceDisconnectPayload) {

--- a/client/src/node.ts
+++ b/client/src/node.ts
@@ -6,8 +6,7 @@ import type {
     PlayPayload,
     SeekPayload,
     ServerMessage,
-    VoiceUpdatePayload,
-    VolumePayload
+    VoiceUpdatePayload
 } from "./types.js";
 import {
     ClientOpCodes,
@@ -277,10 +276,6 @@ export class Node extends EventEmitter {
 
     async sendSeek(guildId: string, data: SeekPayload) {
         await this.rest.post(Routes.seek(this.#requireSession(), guildId), data);
-    }
-
-    async sendVolume(guildId: string, data: VolumePayload) {
-        await this.rest.patch(Routes.volume(this.#requireSession(), guildId), data);
     }
 
     async sendDisconnect(guildId: string) {

--- a/client/src/node.ts
+++ b/client/src/node.ts
@@ -42,8 +42,6 @@ export interface Node {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Node extends EventEmitter {
-    private static readonly NODE_PING_INTERVAL = 30_000;
-
     readonly name: string;
     readonly url: string;
     readonly rest: RESTClient;
@@ -53,7 +51,6 @@ export class Node extends EventEmitter {
     #sessionId: string | null = null;
     #reconnectAttempts = 0;
     #reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
-    #pingInterval: ReturnType<typeof setInterval> | null = null;
     #state: NodeState = NodeState.Disconnected;
     #playerCount = 0;
 
@@ -92,7 +89,6 @@ export class Node extends EventEmitter {
             const onOpen = () => {
                 this.#state = NodeState.Connected;
                 this.#reconnectAttempts = 0;
-                this.#startPingInterval();
                 resolve(null);
             };
 
@@ -113,7 +109,6 @@ export class Node extends EventEmitter {
     disconnect() {
         this.#state = NodeState.Disconnected;
 
-        this.#stopPingInterval();
         this.#stopReconnect();
 
         if (this.#ws) {
@@ -187,9 +182,6 @@ export class Node extends EventEmitter {
             case ServerOpCodes.VoiceDisconnect:
                 this.emit(EventName.VoiceDisconnect, message.d);
                 break;
-            case ServerOpCodes.Pong:
-                this.emit(EventName.Pong, undefined);
-                break;
             case ServerOpCodes.Stats:
                 this.#playerCount = message.d.players;
                 this.#state = message.d.draining ? NodeState.Draining : NodeState.Connected;
@@ -207,7 +199,6 @@ export class Node extends EventEmitter {
 
     #onClose(event: CloseEvent) {
         this.#state = NodeState.Disconnected;
-        this.#stopPingInterval();
 
         this.emit(EventName.Close, { code: event.code, reason: event.reason });
 
@@ -234,20 +225,6 @@ export class Node extends EventEmitter {
             this.#reconnectTimeout = null;
         }
         this.#reconnectAttempts = 0;
-    }
-
-    #startPingInterval() {
-        this.#pingInterval = setInterval(
-            () => this.#send(ClientOpCodes.Ping, undefined),
-            Node.NODE_PING_INTERVAL
-        );
-    }
-
-    #stopPingInterval() {
-        if (!this.#pingInterval) return;
-
-        clearInterval(this.#pingInterval);
-        this.#pingInterval = null;
     }
 
     sendVoiceUpdate(data: VoiceUpdatePayload) {

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -20,7 +20,6 @@ import { unwrap } from "./utils.js";
 
 export interface PlayOptions {
     startTime?: number;
-    volume?: number;
     requesterId?: string;
     filters?: FiltersPayload;
 }
@@ -59,8 +58,7 @@ export class Player {
     #selfMute: boolean;
     #selfDeaf: boolean;
     #state: PlayerState = PlayerState.Idle;
-    #position = 0;
-    #volume = 100;
+
     #current: TrackInfo | null = null;
     #voiceState: VoiceState | null = null;
     #pendingVoice: PendingVoiceState | null = null;
@@ -87,14 +85,6 @@ export class Player {
 
     get state() {
         return this.#state;
-    }
-
-    get position() {
-        return this.#position;
-    }
-
-    get volume() {
-        return this.#volume;
     }
 
     get current() {
@@ -278,7 +268,6 @@ export class Player {
         await this.#node.sendPlay(this.#guildId, {
             url,
             ...(options.startTime !== undefined && { start_time: options.startTime }),
-            ...(options.volume !== undefined && { volume: options.volume }),
             ...(options.requesterId !== undefined && { requester_id: options.requesterId }),
             ...(filters !== undefined && { filters })
         });
@@ -296,17 +285,10 @@ export class Player {
         this.#queue._deactivate();
         await this.#node.sendStop(this.#guildId);
         this.#current = null;
-        this.#state = PlayerState.Idle;
-        this.#position = 0;
     }
 
     async seek(position: number) {
         await this.#node.sendSeek(this.#guildId, { position });
-    }
-
-    async setVolume(volume: number) {
-        this.#volume = Math.max(0, Math.min(1_000, volume));
-        await this.#node.sendVolume(this.#guildId, { volume: this.#volume });
     }
 
     async destroy() {
@@ -360,14 +342,13 @@ export class Player {
         });
     }
 
-    _updateState(data: PlayerUpdatePayload) {
+    _onPlayerUpdate(data: PlayerUpdatePayload) {
         this.#state = data.state;
-        this.#position = data.position;
-        this.#volume = data.volume;
     }
 
     _onTrackStart(data: TrackStartPayload) {
         this.#current = data.track;
+        this.#state = PlayerState.Playing;
     }
 
     _onTrackEnd(data: TrackEndPayload) {
@@ -378,6 +359,10 @@ export class Player {
         this.#queue._onTrackEnd(data.reason !== TrackEndReason.Stopped && data.reason !== TrackEndReason.Replaced);
     }
 
+    _onVoiceConnect() {
+        this.#state = PlayerState.Idle;
+    }
+
     #cleanup() {
         this.#voiceChannelId = null;
         this.#queue._deactivate();
@@ -385,7 +370,6 @@ export class Player {
         this.#pendingVoice = null;
         this.#state = PlayerState.Idle;
         this.#current = null;
-        this.#position = 0;
     }
 
     _onVoiceDisconnect() {
@@ -422,7 +406,6 @@ export class Player {
                 void this.#node.sendPlay(this.#guildId, {
                     url: data.url,
                     start_time: data.position,
-                    volume: data.volume,
                     ...(data.requester_id !== undefined && { requester_id: data.requester_id }),
                     ...(data.filters !== undefined && { filters: data.filters })
                 });

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -90,7 +90,6 @@ export interface VoiceUpdatePayload {
 export interface PlayPayload {
     url: string;
     start_time?: number;
-    volume?: number;
     requester_id?: string;
     filters?: FiltersPayload;
 }
@@ -103,10 +102,6 @@ export interface SeekPayload {
     position: number;
 }
 
-export interface VolumePayload {
-    volume: number;
-}
-
 export interface ReadyPayload {
     session_id: string;
     resumed: boolean;
@@ -115,8 +110,6 @@ export interface ReadyPayload {
 export interface PlayerUpdatePayload {
     guild_id: string;
     state: PlayerState;
-    position: number;
-    volume: number;
 }
 
 export interface TrackInfo {
@@ -186,7 +179,6 @@ export interface MigrateReadyPayload {
     guild_id: string;
     url: string;
     position: number;
-    volume: number;
     state: PlayerState;
     requester_id?: string;
     filters?: FiltersPayload;
@@ -258,6 +250,5 @@ export const Routes = {
     resume: (sessionId: string, guildId: string) => `/sessions/${sessionId}/players/${guildId}/resume` as const,
     stop: (sessionId: string, guildId: string) => `/sessions/${sessionId}/players/${guildId}/stop` as const,
     seek: (sessionId: string, guildId: string) => `/sessions/${sessionId}/players/${guildId}/seek` as const,
-    volume: (sessionId: string, guildId: string) => `/sessions/${sessionId}/players/${guildId}/volume` as const,
     disconnect: (sessionId: string, guildId: string) => `/sessions/${sessionId}/players/${guildId}` as const
 } as const;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,23 +1,21 @@
 import type { Node } from "./node.js";
 
 export enum ClientOpCodes {
-    Ping = 0,
-    VoiceUpdate = 1,
-    PlayerMigrate = 2
+    VoiceUpdate = 0,
+    PlayerMigrate = 1
 }
 
 export enum ServerOpCodes {
-    Pong = 0,
-    Ready = 1,
-    VoiceConnect = 2,
-    VoiceDisconnect = 3,
-    PlayerUpdate = 4,
-    TrackStart = 5,
-    TrackEnd = 6,
-    TrackError = 7,
-    Stats = 8,
-    NodeDraining = 9,
-    MigrateReady = 10
+    Ready = 0,
+    VoiceConnect = 1,
+    VoiceDisconnect = 2,
+    PlayerUpdate = 3,
+    TrackStart = 4,
+    TrackEnd = 5,
+    TrackError = 6,
+    Stats = 7,
+    NodeDraining = 8,
+    MigrateReady = 9
 }
 
 export enum TrackEndReason {
@@ -63,14 +61,12 @@ export type ServerMessage =
     | { op: ServerOpCodes.TrackError; d: TrackErrorPayload; }
     | { op: ServerOpCodes.VoiceConnect; d: VoiceConnectPayload; }
     | { op: ServerOpCodes.VoiceDisconnect; d: VoiceDisconnectPayload; }
-    | { op: ServerOpCodes.Pong; d?: undefined; }
     | { op: ServerOpCodes.Stats; d: StatsPayload; }
     | { op: ServerOpCodes.NodeDraining; d: NodeDrainingPayload; }
     | { op: ServerOpCodes.MigrateReady; d: MigrateReadyPayload; };
 
 export type ClientMessage =
     | { op: ClientOpCodes.VoiceUpdate; d: VoiceUpdatePayload; }
-    | { op: ClientOpCodes.Ping; d?: undefined; }
     | { op: ClientOpCodes.PlayerMigrate; d: PlayerMigratePayload; };
 
 export interface VoiceServerEvent {
@@ -199,7 +195,6 @@ export enum EventName {
     VoiceConnect = "voiceConnect",
     VoiceDisconnect = "voiceDisconnect",
 
-    Pong = "pong",
     Stats = "stats",
 
     NodeDraining = "nodeDraining",
@@ -218,7 +213,6 @@ export interface Events {
     [EventName.QueueError]: QueueErrorPayload;
     [EventName.VoiceConnect]: VoiceConnectPayload;
     [EventName.VoiceDisconnect]: VoiceDisconnectPayload;
-    [EventName.Pong]: undefined;
     [EventName.Stats]: StatsPayload;
     [EventName.NodeDraining]: NodeDrainingPayload;
     [EventName.MigrateReady]: MigrateReadyPayload;

--- a/server/protocol/messages.go
+++ b/server/protocol/messages.go
@@ -32,7 +32,6 @@ type PlayData struct {
 	GuildID   snowflake.ID `json:"guild_id"`
 	URL       string       `json:"url"`
 	StartTime int64        `json:"start_time,omitempty"`
-	Volume    int          `json:"volume,omitempty"`
 }
 
 type GuildData struct {
@@ -44,21 +43,14 @@ type SeekData struct {
 	Position int64        `json:"position"`
 }
 
-type VolumeData struct {
+type PlayerUpdateData struct {
 	GuildID snowflake.ID `json:"guild_id"`
-	Volume  int          `json:"volume"`
+	State   string       `json:"state"`
 }
 
 type ReadyData struct {
 	SessionID string `json:"session_id"`
 	Resumed   bool   `json:"resumed"`
-}
-
-type PlayerUpdateData struct {
-	GuildID  snowflake.ID `json:"guild_id"`
-	State    string       `json:"state"`
-	Position int64        `json:"position"`
-	Volume   int          `json:"volume"`
 }
 
 type TrackInfo struct {
@@ -116,7 +108,6 @@ type MigrateReadyData struct {
 	GuildID     snowflake.ID    `json:"guild_id"`
 	URL         string          `json:"url"`
 	Position    int64           `json:"position"`
-	Volume      int             `json:"volume"`
 	State       string          `json:"state"`
 	RequesterID string          `json:"requester_id,omitempty"`
 	Filters     *filter.Filters `json:"filters,omitempty"`
@@ -133,15 +124,10 @@ type StatsResponse struct {
 type RequestPlay struct {
 	URL         string          `json:"url"`
 	StartTime   int64           `json:"start_time,omitempty"`
-	Volume      int             `json:"volume,omitempty"`
 	RequesterID string          `json:"requester_id,omitempty"`
 	Filters     *filter.Filters `json:"filters,omitempty"`
 }
 
 type RequestSeek struct {
 	Position int64 `json:"position"`
-}
-
-type RequestVolume struct {
-	Volume int `json:"volume"`
 }

--- a/server/protocol/opcodes.go
+++ b/server/protocol/opcodes.go
@@ -1,23 +1,21 @@
 package protocol
 
 const (
-	OpPing          uint8 = 0
-	OpVoiceUpdate   uint8 = 1
-	OpPlayerMigrate uint8 = 2
+	OpVoiceUpdate   uint8 = 0
+	OpPlayerMigrate uint8 = 1
 )
 
 const (
-	OpPong            uint8 = 0
-	OpReady           uint8 = 1
-	OpVoiceConnect    uint8 = 2
-	OpVoiceDisconnect uint8 = 3
-	OpPlayerUpdate    uint8 = 4
-	OpTrackStart      uint8 = 5
-	OpTrackEnd        uint8 = 6
-	OpTrackError      uint8 = 7
-	OpStats           uint8 = 8
-	OpNodeDraining    uint8 = 9
-	OpMigrateReady    uint8 = 10
+	OpReady           uint8 = 0
+	OpVoiceConnect    uint8 = 1
+	OpVoiceDisconnect uint8 = 2
+	OpPlayerUpdate    uint8 = 3
+	OpTrackStart      uint8 = 4
+	OpTrackEnd        uint8 = 5
+	OpTrackError      uint8 = 6
+	OpStats           uint8 = 7
+	OpNodeDraining    uint8 = 8
+	OpMigrateReady    uint8 = 9
 )
 
 const (

--- a/server/server/client.go
+++ b/server/server/client.go
@@ -27,7 +27,6 @@ type Player struct {
 	state       string
 	currentURL  string
 	position    int64
-	volume      int
 	startedAt   time.Time
 	requesterID string
 	filters     *filter.Filters
@@ -150,7 +149,6 @@ func (c *Client) getOrCreatePlayer(guildID snowflake.ID) *Player {
 	player := &Player{
 		guildID: guildID,
 		state:   protocol.PlayerStateIdle,
-		volume:  100,
 	}
 	c.players[guildID] = player
 	return player
@@ -218,18 +216,6 @@ func (p *Player) SetPosition(pos int64) {
 	p.mutex.Unlock()
 }
 
-func (p *Player) GetVolume() int {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-	return p.volume
-}
-
-func (p *Player) SetVolume(vol int) {
-	p.mutex.Lock()
-	p.volume = vol
-	p.mutex.Unlock()
-}
-
 func (p *Player) GetStartedAt() time.Time {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
@@ -292,15 +278,9 @@ func (p *Player) SetPausedState(position int64) {
 	p.mutex.Unlock()
 }
 
-func (p *Player) GetPlayerUpdateData() (state string, position int64, volume int) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-	return p.state, p.position, p.volume
-}
-
-func (p *Player) GetMigrateData() (url string, position int64, volume int, state string, requesterID string, filters *filter.Filters) {
+func (p *Player) GetMigrateData() (url string, position int64, state string, requesterID string, filters *filter.Filters) {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 	calculatedPos := time.Since(p.startedAt).Milliseconds() + p.position
-	return p.currentURL, calculatedPos, p.volume, p.state, p.requesterID, p.filters
+	return p.currentURL, calculatedPos, p.state, p.requesterID, p.filters
 }

--- a/server/server/routes.go
+++ b/server/server/routes.go
@@ -23,7 +23,6 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /sessions/{session_id}/players/{guild_id}/resume", s.withSession(s.routeResume))
 	mux.HandleFunc("POST /sessions/{session_id}/players/{guild_id}/stop", s.withSession(s.routeStop))
 	mux.HandleFunc("POST /sessions/{session_id}/players/{guild_id}/seek", s.withSession(s.routeSeek))
-	mux.HandleFunc("PATCH /sessions/{session_id}/players/{guild_id}/volume", s.withSession(s.routeVolume))
 	mux.HandleFunc("DELETE /sessions/{session_id}/players/{guild_id}", s.withSession(s.routeDisconnect))
 }
 
@@ -100,10 +99,6 @@ func (s *Server) routePlay(client *Client, guildID snowflake.ID, w http.Response
 	}
 	play.Filters = play.Filters.Normalize()
 
-	if play.Volume > 0 {
-		player.SetVolume(play.Volume)
-	}
-
 	s.logger.Info("play requested",
 		slog.String("guild_id", guildID.String()),
 		slog.String("url", play.URL),
@@ -118,7 +113,6 @@ func (s *Server) routePlay(client *Client, guildID snowflake.ID, w http.Response
 
 	player.SetPlayingState(play.URL, play.StartTime, play.RequesterID, play.Filters)
 
-	state, position, volume := player.GetPlayerUpdateData()
 	client.send(protocol.Message{
 		Op: protocol.OpTrackStart,
 		Data: protocol.TrackStartData{
@@ -128,16 +122,6 @@ func (s *Server) routePlay(client *Client, guildID snowflake.ID, w http.Response
 				Duration:    source.Duration(),
 				RequesterID: play.RequesterID,
 			},
-		},
-	})
-
-	client.send(protocol.Message{
-		Op: protocol.OpPlayerUpdate,
-		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: position,
-			Volume:   volume,
 		},
 	})
 
@@ -159,14 +143,11 @@ func (s *Server) routePause(client *Client, guildID snowflake.ID, w http.Respons
 
 	player.SetPausedState(s.voiceManager.Position(client.sessionID, guildID))
 
-	state, position, volume := player.GetPlayerUpdateData()
 	client.send(protocol.Message{
 		Op: protocol.OpPlayerUpdate,
 		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: position,
-			Volume:   volume,
+			GuildID: guildID,
+			State:   player.GetState(),
 		},
 	})
 
@@ -190,14 +171,11 @@ func (s *Server) routeResume(client *Client, guildID snowflake.ID, w http.Respon
 	player.SetStartedAt(time.Now())
 	player.SetPosition(s.voiceManager.Position(client.sessionID, guildID))
 
-	state, position, volume := player.GetPlayerUpdateData()
 	client.send(protocol.Message{
 		Op: protocol.OpPlayerUpdate,
 		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: position,
-			Volume:   volume,
+			GuildID: guildID,
+			State:   player.GetState(),
 		},
 	})
 
@@ -219,14 +197,11 @@ func (s *Server) routeStop(client *Client, guildID snowflake.ID, w http.Response
 
 	player.SetIdleState()
 
-	state, _, volume := player.GetPlayerUpdateData()
 	client.send(protocol.Message{
 		Op: protocol.OpPlayerUpdate,
 		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: 0,
-			Volume:   volume,
+			GuildID: guildID,
+			State:   player.GetState(),
 		},
 	})
 
@@ -260,46 +235,6 @@ func (s *Server) routeSeek(client *Client, guildID snowflake.ID, w http.Response
 
 	player.SetPosition(s.voiceManager.Position(client.sessionID, guildID))
 	player.SetStartedAt(time.Now())
-
-	state, position, volume := player.GetPlayerUpdateData()
-	client.send(protocol.Message{
-		Op: protocol.OpPlayerUpdate,
-		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: position,
-			Volume:   volume,
-		},
-	})
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *Server) routeVolume(client *Client, guildID snowflake.ID, w http.ResponseWriter, r *http.Request) {
-	var vol protocol.RequestVolume
-	if err := json.NewDecoder(r.Body).Decode(&vol); err != nil {
-		writeJSON(w, http.StatusBadRequest, protocol.ErrorResponse{Error: "invalid request body"})
-		return
-	}
-
-	player := client.getPlayer(guildID)
-	if player == nil {
-		writeJSON(w, http.StatusNotFound, protocol.ErrorResponse{Error: "player not found"})
-		return
-	}
-
-	player.SetVolume(vol.Volume)
-
-	state, _, volume := player.GetPlayerUpdateData()
-	client.send(protocol.Message{
-		Op: protocol.OpPlayerUpdate,
-		Data: protocol.PlayerUpdateData{
-			GuildID:  guildID,
-			State:    state,
-			Position: s.voiceManager.Position(client.sessionID, guildID),
-			Volume:   volume,
-		},
-	})
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/server/websocket.go
+++ b/server/server/websocket.go
@@ -299,7 +299,7 @@ func (s *Server) handlePlayerMigrate(client *Client, data json.RawMessage) {
 		return
 	}
 
-	url, position, volume, state, requesterID, filters := player.GetMigrateData()
+	url, position, state, requesterID, filters := player.GetMigrateData()
 	filters = filters.Normalize()
 	client.send(protocol.Message{
 		Op: protocol.OpMigrateReady,
@@ -307,7 +307,6 @@ func (s *Server) handlePlayerMigrate(client *Client, data json.RawMessage) {
 			GuildID:     migrate.GuildID,
 			URL:         url,
 			Position:    position,
-			Volume:      volume,
 			State:       state,
 			RequesterID: requesterID,
 			Filters:     filters,

--- a/server/server/websocket.go
+++ b/server/server/websocket.go
@@ -228,8 +228,6 @@ func (s *Server) handleMessage(client *Client, msgType int, data []byte) {
 	switch msg.Op {
 	case protocol.OpVoiceUpdate:
 		s.handleVoiceUpdate(client, msg.Data)
-	case protocol.OpPing:
-		s.handlePing(client)
 	case protocol.OpPlayerMigrate:
 		s.handlePlayerMigrate(client, msg.Data)
 	default:
@@ -276,13 +274,6 @@ func (s *Server) handleVoiceUpdate(client *Client, data json.RawMessage) {
 			GuildID:   update.GuildID,
 			ChannelID: update.ChannelID,
 		},
-	})
-}
-
-func (s *Server) handlePing(client *Client) {
-	client.send(protocol.Message{
-		Op:   protocol.OpPong,
-		Data: nil,
 	})
 }
 


### PR DESCRIPTION
Remove application-level ping/pong between client and server. WebSocket protocol-level keep-alive (RFC 6455) serves the same purpose via PING_PERIOD and PongHandler in client.go.

Renumber client and server opcodes to start from 0.

```
=== LinkDade Client Integration Tests ===
Discord: ready as dave
LinkDade: connected resumed=false
Voice: connected
  PASS  player.connected is true (0ms)
  PASS  player.state is idle after voice connect (0ms)
  PASS  player.voiceChannelId matches (0ms)
  PASS  player.guildId matches (0ms)
  PASS  play short track triggers TrackStart with correct data
  PASS  player.state is playing after TrackStart
  PASS  short track ends, state goes idle
  PASS  play 24/7 stream
  PASS  pause sends PlayerUpdate with state=paused
  PASS  resume sends PlayerUpdate with state=playing
  PASS  double pause: both events arrive
  PASS  double resume: both events arrive
  PASS  stop sends PlayerUpdate with state=idle
  PASS  play again after stop
  PASS  ends correctly after replay
  PASS  queue.add increases size
  PASS  queue.start plays first, auto-advances to second
  PASS  last queue item finishes → idle
  PASS  queue preserves order
  PASS  queue.skip plays next
  PASS  empty queue.start does nothing
  PASS  queue.clear resets and deactivates
  PASS  queue.remove specific index
  PASS  queue.remove invalid index → undefined
  PASS  queue stress: 20 add, 10 remove, clear
  PASS  queue item with Nightcore filter
  PASS  queue items with different filters per track
  PASS  queue item with requesterId
  PASS  filters.active false when nothing set
  PASS  filters.toggle toggles on and off
  PASS  filters.toggle with explicit boolean
  PASS  all 4 DSP filters active simultaneously
  PASS  filters.clear resets pitch/speed too
  PASS  filters.pitch/speed clamping
  PASS  toPayload with filters active
  PASS  toPayload returns undefined when nothing active
  PASS  play with global Nightcore filter applied
  PASS  play with inline filter overrides global
  PASS  play-now replaces queued track and deactivates queue
  PASS  add to queue while playing
  PASS  stop with active queue prevents auto-advance
  PASS  complete queue: 3 tracks auto-advance → idle
  PASS  add items during auto-advance, all play
  PASS  swap 24/7 stream A → B → A
  PASS  seek on 24/7 stream
  PASS  destroy sets state to idle and disconnects
  PASS  reconnect after destroy
  PASS  play after reconnect
  PASS  VoiceDisconnect event forwarded on destroy
  PASS  rapid pause/resume ×5 cycles
  PASS  rapid play calls: replace track
  PASS  Stats event fires periodically
  PASS  setVolume does not exist on player
  PASS  Routes.volume does not exist
  PASS  PlayerUpdatePayload has no position/volume
  PASS  final play and stop cleanly
  PASS  create two extra voice channels for move tests
  PASS  move bot to channel A while playing stream
  PASS  move to channel B while idle, then play
  PASS  move back to original channel
  PASS  external disconnect while playing
  PASS  reconnect after external kick and play
  PASS  external disconnect while idle
  PASS  reconnect and verify clean state
  PASS  add 9 more nodes (10 total) and connect them
  PASS  getBestNode returns a connected non-draining node
  PASS  getPlayer distributes to best node
  PASS  move player between nodes while playing
  PASS  move player between nodes while idle
  PASS  move back to original node and play
  PASS  moveNode to self is a no-op
  PASS  rapid multi-node moves while idle
  PASS  fetch guilds and create voice channels
  PASS  create players and connect in all 3 guilds
  PASS  play in all 3 guilds simultaneously
  PASS  pause all 3 guilds, verify independent state
  PASS  resume all 3 guilds, verify independent state
  PASS  stop in main guild while others keep playing
  PASS  play short track in main while others still playing
  PASS  destroy players in other guilds
  PASS  draining state is tracked on node
  PASS  getBestNode skips broken connections
  PASS  rapid connect-disconnect on same guild
  PASS  clean up extra voice channels
  PASS  clean up other guild channels and players
  PASS  disconnect extra nodes

Total: 86 | Passed: 86 | Failed: 0
```