### PR TITLE
feat: inactivity leave

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -28,6 +28,7 @@ export interface PlayerOptions {
     voiceChannelId?: string;
     selfMute?: boolean;
     selfDeaf?: boolean;
+    inactivityTimeout?: number;
 }
 
 export type RawVoiceStateUpdate = Pick<GatewayVoiceStateUpdateDispatchData, "user_id" | "channel_id" | "session_id">;
@@ -64,6 +65,8 @@ export class Player {
     #pendingVoice: PendingVoiceState | null = null;
     #migrationTarget: Node | null = null;
     #migrationResolve: ((value: unknown) => void) | null = null;
+    #inactivityTimeout: number;
+    #inactivityTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(client: LinkDaveClient, guildId: string, node: Node, options?: PlayerOptions) {
         this.#client = client;
@@ -73,6 +76,7 @@ export class Player {
         this.#voiceChannelId = options?.voiceChannelId ?? null;
         this.#selfMute = options?.selfMute ?? false;
         this.#selfDeaf = options?.selfDeaf ?? true;
+        this.#inactivityTimeout = options?.inactivityTimeout ?? 0;
     }
 
     get guildId() {
@@ -344,18 +348,23 @@ export class Player {
     }
 
     _onPlayerUpdate(data: PlayerUpdatePayload) {
+        if (data.state === PlayerState.Playing) this.#stopTimer();
+        else if (this.#state === PlayerState.Playing) this.#startTimer();
+
         this.#state = data.state;
     }
 
     _onTrackStart(data: TrackStartPayload) {
         this.#current = data.track;
         this.#state = PlayerState.Playing;
+        this.#stopTimer();
     }
 
     _onTrackEnd(data: TrackEndPayload) {
         if (!this.#queue.active || this.#queue.size === 0) {
-            this.#current = null;
             this.#state = PlayerState.Idle;
+            this.#current = null;
+            this.#startTimer();
         }
         this.#queue._onTrackEnd(data.reason !== TrackEndReason.Stopped && data.reason !== TrackEndReason.Replaced);
     }
@@ -372,6 +381,7 @@ export class Player {
         this.#pendingVoice = null;
         this.#state = PlayerState.Idle;
         this.#current = null;
+        this.#stopTimer();
     }
 
     _onVoiceDisconnect() {
@@ -422,4 +432,35 @@ export class Player {
         this.#migrationResolve(null);
         this.#migrationResolve = null;
     }
+
+    #startTimer() {
+        if (this.#inactivityTimeout <= 0) return;
+        this.#stopTimer();
+
+        this.#inactivityTimer = setTimeout(
+            () => {
+                if (this.#state === PlayerState.Playing) return;
+                this.disconnect();
+
+                if (this.#node.connected) {
+                    void this.#node.sendDisconnect(this.#guildId);
+                }
+
+                this.#client._onPlayerDestroy(this.#guildId);
+
+                this.#client.emit(EventName.VoiceDisconnect, {
+                    guild_id: this.#guildId,
+                    reason: DisconnectReason.Inactivity
+                });
+            },
+            this.#inactivityTimeout
+        );
+    }
+
+    #stopTimer() {
+        if (this.#inactivityTimer === null) return;
+        clearTimeout(this.#inactivityTimer);
+        this.#inactivityTimer = null;
+    }
+
 }

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -372,6 +372,7 @@ export class Player {
     _onVoiceConnect() {
         if (this.#state !== PlayerState.Connecting) return;
         this.#state = PlayerState.Idle;
+        this.#startTimer();
     }
 
     #cleanup() {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -141,7 +141,8 @@ export interface QueueErrorPayload {
 export enum DisconnectReason {
     ConnectionLost = "connection_lost",
     ConnectionFailed = "connection_failed",
-    Requested = "requested"
+    Requested = "requested",
+    Inactivity = "inactivity"
 }
 
 export interface VoiceConnectPayload {


### PR DESCRIPTION
Adds an `inactivityTimeout` option to players that automatically disconnects from voice after a configurable period of idle/paused state. Rebased version of #55 with fixes for connection stability during rapid inactivity cycles.

## Changes

- `client/src/player.ts`: Added `inactivityTimeout` option, internal `#inactivityTimer`, `#startTimer()` and `#stopTimer()` methods. Timer starts on track end / pause / stop and cancels on play / resume. Fires `VoiceDisconnect` with `DisconnectReason.Inactivity`.
- `client/src/types.ts`: Added `Inactivity` to the `DisconnectReason` enum.

## Test Results

```
  PASS  inactivity: track end triggers disconnect with correct reason (8202ms)
  PASS  inactivity: playing stream prevents timer from firing (11436ms)
  PASS  inactivity: pause triggers disconnect after timeout (4279ms)
  PASS  inactivity: stop triggers disconnect after timeout (6971ms)
  PASS  inactivity: queue auto-advance keeps alive, last track triggers disconnect (16163ms)
  PASS  inactivity: play cancels pending timer (no disconnect while playing) (12931ms)
  PASS  inactivity: manual destroy cancels pending timer (14716ms)
  PASS  inactivity: reconnect after inactivity disconnect works (12697ms)
  PASS  inactivity: race: rapid start+pause triggers inactivity after pause delay (5577ms)
  PASS  inactivity: timer resets on each state transition (16871ms)
  PASS  inactivity: double end-to-end: play-idle-inactivity-reconnect-play (19401ms)
  PASS  inactivity: short track with fast timeout (7705ms)

Total: 102 | Passed: 102 | Failed: 0
```
