### PR TITLE
refactor: queue & track error parity

### DIFF
--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -76,10 +76,9 @@ export class Queue {
             .play(item.uri, item.options, true)
             .then(
                 () => null,
-                (error_: unknown) => {
-                    const error = error_ instanceof Error ? error_ : new Error(String(error_));
-                    const payload: QueueErrorPayload = { guild_id: this.#player.guildId, url: item.uri, error };
-                    this.#player.node.emit(EventName.QueueError, payload);
+                (error: unknown) => {
+                    const message = error instanceof Error ? error.message : String(error);
+                    this.#player.node.emit(EventName.QueueError, { guild_id: this.#player.guildId, item, error: message });
                     this._onTrackEnd(true);
                 }
             );

--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -1,5 +1,5 @@
 import type { Player, PlayOptions } from "./player.js";
-import { EventName, type QueueErrorPayload } from "./types.js";
+import { EventName } from "./types.js";
 
 export interface QueueItem {
     uri: string;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,5 @@
 import type { Node } from "./node.js";
+import type { QueueItem } from "./queue.js";
 
 export enum ClientOpCodes {
     VoiceUpdate = 0,
@@ -134,8 +135,8 @@ export interface TrackErrorPayload {
 
 export interface QueueErrorPayload {
     guild_id: string;
-    url: string;
-    error: Error;
+    item: QueueItem;
+    error: string;
 }
 
 export enum DisconnectReason {


### PR DESCRIPTION
`QueueErrorPayload` had a slightly different, but annoying, imparity compared to `TrackErrorPayload`