### PR TITLE
perf: switch to distroless & build-in healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,53 @@
 FROM golang:1.26 AS builder
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libopus-dev \
     libopusfile-dev \
     gcc \
-    git \
     curl \
     unzip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN ARCH=$(uname -m) && \
+    mkdir -p /opt/libs/lib /opt/libs/include && \
+    cp /usr/lib/${ARCH}-linux-gnu/libopus.so.0*     /opt/libs/lib/ && \
+    cp /usr/lib/${ARCH}-linux-gnu/libopusfile.so.0* /opt/libs/lib/ && \
+    cp /usr/lib/${ARCH}-linux-gnu/libogg.so.0*      /opt/libs/lib/
 
 ENV LIBDAVE_VERSION=1.1.1
 
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         GITHUB_ARCH="X64"; \
-        LIBDAVE_SHA256="2470a131dbf39a820d893ba3d6f01373fc597868caffd6a30a8746e441ed5ede"; \
+        SHA256="2470a131dbf39a820d893ba3d6f01373fc597868caffd6a30a8746e441ed5ede"; \
     elif [ "$ARCH" = "aarch64" ]; then \
         GITHUB_ARCH="ARM64"; \
-        LIBDAVE_SHA256="2848ca62da5c8303626cfa410827f37735455f614256311fc320b35c7c6a1975"; \
+        SHA256="2848ca62da5c8303626cfa410827f37735455f614256311fc320b35c7c6a1975"; \
     else \
-        echo "Unsupported architecture: $ARCH"; exit 1; \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \
-    curl -fsL "https://github.com/discord/libdave/releases/download/v${LIBDAVE_VERSION}/cpp/libdave-Linux-${GITHUB_ARCH}-boringssl.zip" -o /tmp/libdave.zip && \
-    echo "${LIBDAVE_SHA256}  /tmp/libdave.zip" | sha256sum -c -
-
-RUN mkdir -p ~/.local/lib ~/.local/include ~/.local/lib/pkgconfig && \
-    unzip -j -o /tmp/libdave.zip "include/dave/dave.h" -d ~/.local/include && \
-    unzip -j -o /tmp/libdave.zip "lib/libdave.so" -d ~/.local/lib && \
+    curl -fsL "https://github.com/discord/libdave/releases/download/v${LIBDAVE_VERSION}/cpp/libdave-Linux-${GITHUB_ARCH}-boringssl.zip" \
+        -o /tmp/libdave.zip && \
+    echo "${SHA256}  /tmp/libdave.zip" | sha256sum -c - && \
+    unzip -j /tmp/libdave.zip "include/dave/dave.h" -d /opt/libs/include && \
+    unzip -j /tmp/libdave.zip "lib/libdave.so"      -d /opt/libs/lib && \
     rm /tmp/libdave.zip
 
-RUN echo "prefix=$HOME/.local\nexec_prefix=\${prefix}\nlibdir=\${exec_prefix}/lib\nincludedir=\${prefix}/include\n\nName: dave\nDescription: Discord Audio & Video End-to-End Encryption (DAVE) Protocol\nVersion: ${LIBDAVE_VERSION}\nURL: https://github.com/discord/libdave\nLibs: -L\${libdir} -ldave -Wl,-rpath,\${libdir}\nCflags: -I\${includedir}" > ~/.local/lib/pkgconfig/dave.pc
+RUN mkdir -p /opt/libs/lib/pkgconfig && printf "\
+prefix=/opt/libs\n\
+exec_prefix=\${prefix}\n\
+libdir=\${exec_prefix}/lib\n\
+includedir=\${prefix}/include\n\
+\n\
+Name: dave\n\
+Description: Discord DAVE Protocol\n\
+Version: %s\n\
+Libs: -L\${libdir} -ldave -Wl,-rpath,/usr/lib\n\
+Cflags: -I\${includedir}\n" "${LIBDAVE_VERSION}" > /opt/libs/lib/pkgconfig/dave.pc
 
-ENV PKG_CONFIG_PATH="/root/.local/lib/pkgconfig"
-ENV LD_LIBRARY_PATH="/root/.local/lib"
+ENV PKG_CONFIG_PATH=/opt/libs/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/libs/lib
 
 WORKDIR /app
 
@@ -43,24 +57,29 @@ RUN go mod download
 COPY . .
 
 ARG BUILD_VERSION
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" -o linkdave ./cmd/linkdave
+RUN CGO_ENABLED=1 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
+    -o linkdave ./cmd/linkdave
 
-FROM debian:trixie-slim
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o healthcheck ./cmd/healthcheck
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    libopus0 \
-    libopusfile0 \
-    libstdc++6 \
-    && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/linkdave /usr/local/bin/linkdave
-COPY --from=builder /root/.local/lib/libdave.so /usr/local/lib/
-RUN ldconfig
+FROM gcr.io/distroless/cc-debian13
 
-RUN useradd -m -s /bin/bash linkdave
-USER linkdave
+COPY --from=builder /app/linkdave               /usr/local/bin/linkdave
+COPY --from=builder /app/healthcheck            /usr/local/bin/healthcheck
+COPY --from=builder /opt/libs/lib/libdave.so        /usr/lib/
+COPY --from=builder /opt/libs/lib/libopus.so.0      /usr/lib/
+COPY --from=builder /opt/libs/lib/libopusfile.so.0  /usr/lib/
+COPY --from=builder /opt/libs/lib/libogg.so.0       /usr/lib/
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/usr/local/bin/healthcheck"]
+
+USER nonroot
 
 EXPOSE 8080
 
-ENTRYPOINT ["linkdave"]
+ENTRYPOINT ["/usr/local/bin/linkdave"]

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linkdave",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "author": "Luna Seemann <luna@wamellow.com> (http://shi.gg)",
     "description": "TypeScript client library for linkdave Discord audio streaming server",
     "repository": {

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+	"os"
+)
+
+func main() {
+	resp, err := http.Get("http://localhost:8080/health")
+	if err != nil || resp.StatusCode != http.StatusNoContent {
+		os.Exit(1)
+	}
+}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
-	resp, err := http.Get("http://localhost:8080/health")
+	client := &http.Client{Timeout: 4 * time.Second}
+	resp, err := client.Get("http://localhost:8080/health")
 	if err != nil || resp.StatusCode != http.StatusNoContent {
 		os.Exit(1)
 	}
+	defer resp.Body.Close()
 }

--- a/compose.yml
+++ b/compose.yml
@@ -8,12 +8,6 @@ services:
         restart: unless-stopped
         ports:
             - "18080:8080"
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-            interval: 30s
-            timeout: 3s
-            start_period: 5s
-            retries: 3
         logging:
             driver: json-file
             options:


### PR DESCRIPTION
```
❯ docker ps
CONTAINER ID   IMAGE             COMMAND                  CREATED          STATUS                    PORTS                                           NAMES
448ddff0b1a2   linkdave:latest   "/usr/local/bin/link…"   51 seconds ago   Up 50 seconds (healthy)   0.0.0.0:18080->8080/tcp, [::]:18080->8080/tcp   linkdave
881d324ab145   mw-tts            "./server"               28 minutes ago   Up 28 minutes             0.0.0.0:7007->8080/tcp, [::]:7007->8080/tcp     mw-tts
```

<table>
<tr>
 <td>
 <td><b>before
 <td><b>after
<tr>
 <td><b>disk usage
 <td>158mb
 <td>84mb
<tr>
 <td><b>container size
 <td>31mb
 <td>23mb
</table>