### PR TITLE
fix: unstick queue on invalid stream

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -264,13 +264,15 @@ export class Player {
 
     async play(url: string, options: PlayOptions = {}, isFromQueue = false) {
         if (!isFromQueue) this.#queue._deactivate();
+        await this.#sendPlay(url, options);
+    }
 
-        const [, error] = await unwrap(this.#sendPlay(url, options));
-        if (error) {
-            this.#state = PlayerState.Idle;
-            this.#current = null;
-            throw error;
-        }
+    _onQueueEmpty() {
+        if (this.#state === PlayerState.Idle) return;
+
+        this.#state = PlayerState.Idle;
+        this.#current = null;
+        this.#startTimer();
     }
 
     async #sendPlay(url: string, options: PlayOptions = {}) {

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -264,7 +264,13 @@ export class Player {
 
     async play(url: string, options: PlayOptions = {}, isFromQueue = false) {
         if (!isFromQueue) this.#queue._deactivate();
-        await this.#sendPlay(url, options);
+
+        const [, error] = await unwrap(this.#sendPlay(url, options));
+        if (error) {
+            this.#state = PlayerState.Idle;
+            this.#current = null;
+            throw error;
+        }
     }
 
     async #sendPlay(url: string, options: PlayOptions = {}) {

--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -99,6 +99,6 @@ export class Queue {
             this.#player._onQueueEmpty();
         }
 
-        return false;
+        return this.#active;
     }
 }

--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -37,12 +37,13 @@ export class Queue {
             return true;
         }
 
-        return this.#playCurrentTrack();
+        return this.#playCurrentTrack(true);
     }
 
     remove(index: number) {
         if (index < 0 || index >= this.#tracks.length) return undefined;
         const [removed] = this.#tracks.splice(index, 1);
+
         return removed;
     }
 
@@ -63,34 +64,41 @@ export class Queue {
         return this.#active;
     }
 
-    _onTrackEnd(finished: boolean) {
+    _onTrackEnd(finished: boolean, isFromSkip = false) {
         if (!this.#active || !finished) return;
 
         if (this.#tracks.length === 0) {
             this.#active = false;
+
+            if (!isFromSkip) {
+                this.#player._onQueueEmpty();
+            }
+
             return;
         }
 
-        void this.#playCurrentTrack();
+        void this.#playCurrentTrack(isFromSkip);
     }
 
     _deactivate() {
         this.#active = false;
     }
 
-    async #playCurrentTrack() {
+    async #playCurrentTrack(isFromSkip = false) {
         const item = this.#tracks.shift();
         if (!item) return false;
 
         const [, error] = await unwrap(this.#player.play(item.uri, item.options, true));
-        if (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            this.#player.node.emit(EventName.QueueError, { guild_id: this.#player.guildId, item, error: message });
-            this._onTrackEnd(true);
+        if (!error) return true;
 
-            return false;
+        const message = error instanceof Error ? error.message : String(error);
+        this.#player.node.emit(EventName.QueueError, { guild_id: this.#player.guildId, item, error: message });
+        this._onTrackEnd(true, isFromSkip);
+
+        if (!this.#active && !isFromSkip) {
+            this.#player._onQueueEmpty();
         }
 
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
When a queue contains a mix of playable and unplayable URLs, the client can enter an inconsistent state where `player.state === "playing"` but `player.queue.active === false`.

This happens when a track fails *during the REST play request* (before any server-side playback begins), and that track happens to be the last item in the queue. The queue correctly advances past the failed track and marks itself inactive once empty, but the player state is never updated because no server events (`TrackStart` / `TrackEnd`) are generated for a request that never reached the audio pipeline. The resulting state — `player.state === "playing"` with no active queue and no actual playback -- persists indefinitely.

<img width="1863" height="1249" alt="image" src="https://github.com/user-attachments/assets/a8559b9e-60f4-421a-ab35-32586b08794d" />

This fix was tested through my internal test suite:
```
  PASS  queue: working + broken → state idle after queue empties (3429ms)
  PASS  queue: only broken URLs → state idle after queue empties (544ms)
  PASS  queue: working + broken + working → middle broken skipped (6562ms)
  PASS  queue: broken → broken → working → working (recovery after errors) (6546ms)
  PASS  play() with broken URL directly sets state to idle (328ms)
  PASS  queue: broken URLs with inactivity timeout → disconnect after queue empties (5093ms)

Total: 112 | Passed: 112 | Failed: 0
```