### PR TITLE
fix: queue play race

### DIFF
--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -11,7 +11,6 @@ export class Queue {
     readonly #player: Player;
     readonly #tracks: QueueItem[] = [];
     #active = false;
-    #playing = false;
 
     constructor(player: Player) {
         this.#player = player;
@@ -24,7 +23,7 @@ export class Queue {
 
     start() {
         if (this.#tracks.length === 0) return false;
-        if (this.#playing) return false;
+        if (this.#active) return false;
         this.#active = true;
 
         return this.#playCurrentTrack();
@@ -52,7 +51,6 @@ export class Queue {
     clear() {
         this.#tracks.length = 0;
         this.#active = false;
-        this.#playing = false;
     }
 
     get tracks(): readonly QueueItem[] {
@@ -88,17 +86,10 @@ export class Queue {
     }
 
     async #playCurrentTrack(isFromSkip = false) {
-        this.#playing = true;
-
         const item = this.#tracks.shift();
-        if (!item) {
-            this.#playing = false;
-            return false;
-        }
+        if (!item) return false;
 
         const [, error] = await unwrap(this.#player.play(item.uri, item.options, true));
-        this.#playing = false;
-
         if (!error) return true;
 
         const message = error instanceof Error ? error.message : String(error);

--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -11,6 +11,7 @@ export class Queue {
     readonly #player: Player;
     readonly #tracks: QueueItem[] = [];
     #active = false;
+    #playing = false;
 
     constructor(player: Player) {
         this.#player = player;
@@ -23,6 +24,7 @@ export class Queue {
 
     start() {
         if (this.#tracks.length === 0) return false;
+        if (this.#playing) return false;
         this.#active = true;
 
         return this.#playCurrentTrack();
@@ -50,6 +52,7 @@ export class Queue {
     clear() {
         this.#tracks.length = 0;
         this.#active = false;
+        this.#playing = false;
     }
 
     get tracks(): readonly QueueItem[] {
@@ -85,10 +88,17 @@ export class Queue {
     }
 
     async #playCurrentTrack(isFromSkip = false) {
+        this.#playing = true;
+
         const item = this.#tracks.shift();
-        if (!item) return false;
+        if (!item) {
+            this.#playing = false;
+            return false;
+        }
 
         const [, error] = await unwrap(this.#player.play(item.uri, item.options, true));
+        this.#playing = false;
+
         if (!error) return true;
 
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
when adding a slow-resolving track to the queue (e.g. a remote server with high latency due to tts generation), followed by a fast-resolving track before the first begins playing, the queue skips the first track entirely -- the fast track starts immediately and the slow track is overwritten, playing briefly or not at all

<img width="947" height="390" alt="image" src="https://github.com/user-attachments/assets/5285fa66-f14d-4b24-85d1-96a507b6221c" />

```
  PASS  queue.add increases size (0ms)
  PASS  queue.start plays first, auto-advances to second (3253ms)
  PASS  last queue item finishes → idle (3181ms)
  PASS  queue preserves order (450ms)
  PASS  queue.skip plays next (537ms)
  PASS  empty queue.start does nothing (0ms)
  PASS  queue.clear resets and deactivates (0ms)
  PASS  queue.remove specific index (0ms)
  PASS  queue.remove invalid index → undefined (0ms)
  PASS  queue stress: 20 add, 10 remove, clear (0ms)
  PASS  queue item with Nightcore filter (1915ms)
  PASS  queue items with different filters per track (8239ms)
  PASS  queue item with requesterId (3216ms)
  PASS  play-now replaces queued track and deactivates queue (1071ms)
  PASS  add to queue while playing (3776ms)
  PASS  stop with active queue prevents auto-advance (494ms)
  PASS  complete queue: 3 tracks auto-advance → idle (9661ms)
  PASS  inactivity: queue auto-advance keeps alive, last track triggers disconnect (16447ms)
  PASS  queue: working + broken → state idle after queue empties (3418ms)
  PASS  queue: only broken URLs → state idle after queue empties (546ms)
  PASS  queue: working + broken + working → middle broken skipped (6491ms)
  PASS  queue: broken → broken → working → working (recovery after errors) (6506ms)
  PASS  queue: broken URLs with inactivity timeout → disconnect after queue empties (4811ms)
  PASS  queue skip to bad URL while playing keeps state Playing (1577ms)
  PASS  queue race: verify slow URL resolves correctly (6251ms)
  PASS  queue race: slow + fast — slow plays first, fast queues behind (9463ms)
  PASS  queue race: slow then 3 fast adds while resolving — all 4 play in order (15850ms)
  PASS  queue race: start() returns false when play is already in-flight (3526ms)
  PASS  queue race: multiple concurrent start() calls are all no-ops after first (3536ms)
  PASS  queue race: slow resolves, fast added+started during slow playback — fast queues normally (9457ms)
  PASS  queue race: skip during slow resolution skips to next track (3538ms)
  PASS  queue race: direct play() while queue is resolving slow track — deactivates queue, plays immediately (987ms)
  PASS  queue race: stop during slow resolution — queue deactivated, nothing plays (1103ms)
  PASS  queue race: clear during slow resolution — queue emptied, nothing plays (1102ms)

Total: 125 | Passed: 125 | Failed: 0
```
*I removed tests unrelated to queue handling*
