### PR TITLE
fix: queue connect stall

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -374,13 +374,19 @@ export class Player {
             this.#current = null;
             this.#startTimer();
         }
+
         this.#queue._onTrackEnd(data.reason !== TrackEndReason.Stopped && data.reason !== TrackEndReason.Replaced);
     }
 
     _onVoiceConnect() {
         if (this.#state !== PlayerState.Connecting) return;
+
         this.#state = PlayerState.Idle;
-        this.#startTimer();
+        this.#queue._onConnectReady();
+
+        if (!this.#queue.active) {
+            this.#startTimer();
+        }
     }
 
     #cleanup() {

--- a/client/src/queue.ts
+++ b/client/src/queue.ts
@@ -1,5 +1,5 @@
 import type { Player, PlayOptions } from "./player.js";
-import { EventName } from "./types.js";
+import { EventName, PlayerState } from "./types.js";
 import { unwrap } from "./utils.js";
 
 export interface QueueItem {
@@ -25,6 +25,10 @@ export class Queue {
         if (this.#tracks.length === 0) return false;
         if (this.#active) return false;
         this.#active = true;
+
+        if (this.#player.state === PlayerState.Connecting) {
+            return true;
+        }
 
         return this.#playCurrentTrack();
     }
@@ -83,6 +87,17 @@ export class Queue {
 
     _deactivate() {
         this.#active = false;
+    }
+
+    _onConnectReady() {
+        if (!this.#active) return;
+
+        if (this.#tracks.length === 0) {
+            this.#active = false;
+            return;
+        }
+
+        void this.#playCurrentTrack();
     }
 
     async #playCurrentTrack(isFromSkip = false) {


### PR DESCRIPTION
prevents queue errors when tracks are added to the queue while the player is still connecting