### PR TITLE
feat: connecting player getter

### DIFF
--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -111,8 +111,8 @@ export class Player {
         return this.#state === PlayerState.Paused;
     }
 
-    get connectable() {
-        return this.#state !== PlayerState.Connecting;
+    get connecting() {
+        return this.#state === PlayerState.Connecting;
     }
 
     get connected() {
@@ -129,7 +129,7 @@ export class Player {
             throw new RangeError("No voice channel ID provided");
         }
 
-        if (this.#state !== PlayerState.Connecting) {
+        if (this.connecting) {
             throw new Error("Player is already connecting");
         }
 

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -115,6 +115,10 @@ export class Player {
         return this.#voiceState !== null;
     }
 
+    get connectable() {
+        return !this.connected && this.#state !== PlayerState.Connecting;
+    }
+
     get filters(): PlayerFilters {
         return this.#filters;
     }
@@ -123,6 +127,10 @@ export class Player {
         const targetChannel = channelId ?? this.#voiceChannelId;
         if (!targetChannel) {
             throw new RangeError("No voice channel ID provided");
+        }
+
+        if (!this.connectable) {
+            throw new Error("Player is already connecting or connected");
         }
 
         this.#voiceChannelId = targetChannel;

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -111,12 +111,12 @@ export class Player {
         return this.#state === PlayerState.Paused;
     }
 
-    get connected() {
-        return this.#voiceState !== null;
+    get connectable() {
+        return this.#state !== PlayerState.Connecting;
     }
 
-    get connectable() {
-        return !this.connected && this.#state !== PlayerState.Connecting;
+    get connected() {
+        return this.#voiceState !== null;
     }
 
     get filters(): PlayerFilters {
@@ -129,8 +129,8 @@ export class Player {
             throw new RangeError("No voice channel ID provided");
         }
 
-        if (!this.connectable && targetChannel === this.#voiceChannelId) {
-            throw new Error("Player is already connecting or connected");
+        if (this.#state !== PlayerState.Connecting) {
+            throw new Error("Player is already connecting");
         }
 
         this.#voiceChannelId = targetChannel;

--- a/client/src/player.ts
+++ b/client/src/player.ts
@@ -129,7 +129,7 @@ export class Player {
             throw new RangeError("No voice channel ID provided");
         }
 
-        if (!this.connectable) {
+        if (!this.connectable && targetChannel === this.#voiceChannelId) {
             throw new Error("Player is already connecting or connected");
         }
 


### PR DESCRIPTION
Adds a `player.connecting` getter, returning true when the player is `PlayerState.Connecting`.

`player.connect()` will now throw if the player is connecting