### PR TITLE
fix: race causing SIGSEGV in mp3 decode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hraban/opus v0.0.0-20251117090126-c76ea7e21bf3
-	github.com/tosone/minimp3 v1.0.2
+	github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sasha-s/go-csync v0.0.0-20240107134140-fcbab37b09ad h1:qIQkSlF5vAUHxEmTbaqt1hkJ/t6skqEGYiMag343ucI=
 github.com/sasha-s/go-csync v0.0.0-20240107134140-fcbab37b09ad/go.mod h1:/pA7k3zsXKdjjAiUhB5CjuKib9KJGCaLvZwtxGC8U0s=
+github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82 h1:CHFvPPb5wLYOZDGEN4NiEUEZRMDBSKWuVY1wBeWiKvc=
+github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82/go.mod h1:hAMWIl1N2SX+bWOcDRszUNf1sp0fYkPb0AY5xvqvA/Q=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tosone/minimp3 v1.0.2 h1:htFE2EbP7Y4CJ8KGW9c55tKWRpzv9kXkEmCYGxFzVjA=
-github.com/tosone/minimp3 v1.0.2/go.mod h1:N6vjknGR7PboMTyJVhe/7RHNQiIc0jWZxFKlSWdfzwc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=

--- a/server/audio/source/mp3.go
+++ b/server/audio/source/mp3.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hraban/opus"
 	"github.com/shi-gg/linkdave/server/audio/filter"
-	"github.com/tosone/minimp3"
+	"github.com/shi-gg/minimp3"
 )
 
 const (


### PR DESCRIPTION
issue was fixed in https://github.com/shi-gg/minimp3/pull/1

```
mw-linkdave  | goroutine 26767 gp=0x2fa13de0e1e0 m=nil [IO wait]:
mw-linkdave  | runtime.gopark(0x2fa13dc1d040?, 0x2fa13e3b1b80?, 0x2c?, 0xb?, 0xb?)
mw-linkdave  | 	/usr/local/go/src/runtime/proc.go:462 +0xce fp=0x2fa13e3b1b28 sp=0x2fa13e3b1b08 pc=0x48852e
mw-linkdave  | runtime.netpollblock(0x4a55d8?, 0x419206?, 0x0?)
mw-linkdave  | 	/usr/local/go/src/runtime/netpoll.go:575 +0xf7 fp=0x2fa13e3b1b60 sp=0x2fa13e3b1b28 pc=0x44c3d7
mw-linkdave  | internal/poll.runtime_pollWait(0x7fdc7c1df800, 0x72)
mw-linkdave  | 	/usr/local/go/src/runtime/netpoll.go:351 +0x85 fp=0x2fa13e3b1b80 sp=0x2fa13e3b1b60 pc=0x487705
mw-linkdave  | internal/poll.(*pollDesc).wait(0x2fa13db5a600?, 0x2fa13dd20000?, 0x0)
mw-linkdave  | 	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27 fp=0x2fa13e3b1ba8 sp=0x2fa13e3b1b80 pc=0x4ebe27
mw-linkdave  | internal/poll.(*pollDesc).waitRead(...)
mw-linkdave  | 	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
mw-linkdave  | internal/poll.(*FD).Read(0x2fa13db5a600, {0x2fa13dd20000, 0x1000, 0x1000})
mw-linkdave  | 	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x2ae fp=0x2fa13e3b1c40 sp=0x2fa13e3b1ba8 pc=0x4ecace
mw-linkdave  | net.(*netFD).Read(0x2fa13db5a600, {0x2fa13dd20000?, 0x0?, 0x1?})
mw-linkdave  | 	/usr/local/go/src/net/fd_posix.go:68 +0x25 fp=0x2fa13e3b1c88 sp=0x2fa13e3b1c40 pc=0x58dfc5
mw-linkdave  | net.(*conn).Read(0x2fa13db821a0, {0x2fa13dd20000?, 0x2fa13e01b0b0?, 0x8376c0?})
mw-linkdave  | 	/usr/local/go/src/net/net.go:196 +0x45 fp=0x2fa13e3b1cd0 sp=0x2fa13e3b1c88 pc=0x597485
mw-linkdave  | net/http.(*persistConn).Read(0x2fa13dc1d040, {0x2fa13dd20000?, 0x8e2400?, 0xbfa860?})
mw-linkdave  | 	/usr/local/go/src/net/http/transport.go:2174 +0x47 fp=0x2fa13e3b1d30 sp=0x2fa13e3b1cd0 pc=0x6b6a27
mw-linkdave  | bufio.(*Reader).fill(0x2fa13db4a180)
mw-linkdave  | 	/usr/local/go/src/bufio/bufio.go:113 +0x103 fp=0x2fa13e3b1d68 sp=0x2fa13e3b1d30 pc=0x62b463
mw-linkdave  | bufio.(*Reader).Peek(0x2fa13db4a180, 0x1)
mw-linkdave  | 	/usr/local/go/src/bufio/bufio.go:152 +0x53 fp=0x2fa13e3b1d80 sp=0x2fa13e3b1d68 pc=0x62b593
mw-linkdave  | net/http.(*persistConn).readLoop(0x2fa13dc1d040)
mw-linkdave  | 	/usr/local/go/src/net/http/transport.go:2330 +0x172 fp=0x2fa13e3b1fc8 sp=0x2fa13e3b1d80 pc=0x6b7532
mw-linkdave  | net/http.(*Transport).dialConn.gowrap2()
mw-linkdave  | 	/usr/local/go/src/net/http/transport.go:1994 +0x17 fp=0x2fa13e3b1fe0 sp=0x2fa13e3b1fc8 pc=0x6b5f57
mw-linkdave  | runtime.goexit({})
mw-linkdave  | 	/usr/local/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0x2fa13e3b1fe8 sp=0x2fa13e3b1fe0 pc=0x48fbe1
mw-linkdave  | created by net/http.(*Transport).dialConn in goroutine 26766
mw-linkdave  | 	/usr/local/go/src/net/http/transport.go:1994 +0x16ac
mw-linkdave  | 
mw-linkdave  | goroutine 25647 gp=0x2fa13de0e5a0 m=nil [chan receive]:
mw-linkdave  | runtime.gopark(0x2fa13dbf81d0?, 0x2fa13dbf80e0?, 0x0?, 0x0?, 0x8dc8c8?)
mw-linkdave  | 	/usr/local/go/src/runtime/proc.go:462 +0xce fp=0x2fa13e3c76c0 sp=0x2fa13e3c76a0 pc=0x48852e
mw-linkdave  | runtime.chanrecv(0x2fa13dbf80e0, 0x0, 0x1)
mw-linkdave  | 	/usr/local/go/src/runtime/chan.go:667 +0x4ae fp=0x2fa13e3c7738 sp=0x2fa13e3c76c0 pc=0x41c4ee
mw-linkdave  | runtime.chanrecv1(0x989680?, 0x2fa13e036c00?)
mw-linkdave  | 	/usr/local/go/src/runtime/chan.go:509 +0x12 fp=0x2fa13e3c7760 sp=0x2fa13e3c7738 pc=0x41c012
mw-linkdave  | github.com/tosone/minimp3.NewDecoder.func1()
mw-linkdave  | 	/go/pkg/mod/github.com/tosone/minimp3@v1.0.2/decode.go:74 +0x93 fp=0x2fa13e3c77e0 sp=0x2fa13e3c7760 pc=0x6c8fb3
mw-linkdave  | runtime.goexit({})
mw-linkdave  | 	/usr/local/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0x2fa13e3c77e8 sp=0x2fa13e3c77e0 pc=0x48fbe1
mw-linkdave  | created by github.com/tosone/minimp3.NewDecoder in goroutine 26384
mw-linkdave  | 	/go/pkg/mod/github.com/tosone/minimp3@v1.0.2/decode.go:66 +0x1ec
mw-linkdave  | 
mw-linkdave  | goroutine 26917 gp=0x2fa13df232c0 m=nil [sleep]:
mw-linkdave  | runtime.gopark(0xa6420e63534b5?, 0x0?, 0x0?, 0x0?, 0x0?)
mw-linkdave  | 	/usr/local/go/src/runtime/proc.go:462 +0xce fp=0x2fa13db20f08 sp=0x2fa13db20ee8 pc=0x48852e
mw-linkdave  | time.Sleep(0x1312d00)
mw-linkdave  | 	/usr/local/go/src/runtime/time.go:363 +0x165 fp=0x2fa13db20f60 sp=0x2fa13db20f08 pc=0x48c425
mw-linkdave  | github.com/disgoorg/disgo/voice.(*defaultAudioSender).open(0x2fa13dbb2880)
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/audio_sender.go:87 +0x19e fp=0x2fa13db20fc8 sp=0x2fa13db20f60 pc=0x74f95e
mw-linkdave  | github.com/disgoorg/disgo/voice.(*defaultAudioSender).Open.gowrap1()
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/audio_sender.go:68 +0x17 fp=0x2fa13db20fe0 sp=0x2fa13db20fc8 pc=0x74f797
mw-linkdave  | runtime.goexit({})
mw-linkdave  | 	/usr/local/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0x2fa13db20fe8 sp=0x2fa13db20fe0 pc=0x48fbe1
mw-linkdave  | created by github.com/disgoorg/disgo/voice.(*defaultAudioSender).Open in goroutine 66
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/audio_sender.go:68 +0x4f
mw-linkdave  | 
mw-linkdave  | goroutine 26935 gp=0x2fa13de0f0e0 m=nil [select]:
mw-linkdave  | runtime.gopark(0x2fa13e3c9780?, 0x2?, 0xa8?, 0x94?, 0x2fa13e3c9724?)
mw-linkdave  | 	/usr/local/go/src/runtime/proc.go:462 +0xce fp=0x2fa13e3c95a0 sp=0x2fa13e3c9580 pc=0x48852e
mw-linkdave  | runtime.selectgo(0x2fa13e3c9780, 0x2fa13e3c9720, 0x2fa13dc54918?, 0x0, 0x2fa13dd810f0?, 0x1)
mw-linkdave  | 	/usr/local/go/src/runtime/select.go:351 +0xaa5 fp=0x2fa13e3c96d0 sp=0x2fa13e3c95a0 pc=0x466c85
mw-linkdave  | github.com/disgoorg/disgo/voice.(*gatewayImpl).heartbeat(0x2fa13dc0a100)
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/gateway.go:375 +0x176 fp=0x2fa13e3c97c8 sp=0x2fa13e3c96d0 pc=0x7559b6
mw-linkdave  | github.com/disgoorg/disgo/voice.(*gatewayImpl).listen.gowrap5()
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/gateway.go:536 +0x17 fp=0x2fa13e3c97e0 sp=0x2fa13e3c97c8 pc=0x7579b7
mw-linkdave  | runtime.goexit({})
mw-linkdave  | 	/usr/local/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0x2fa13e3c97e8 sp=0x2fa13e3c97e0 pc=0x48fbe1
mw-linkdave  | created by github.com/disgoorg/disgo/voice.(*gatewayImpl).listen in goroutine 26934
mw-linkdave  | 	/go/pkg/mod/github.com/disgoorg/disgo@v0.19.4-0.20260513223554-8fafd9677292/voice/gateway.go:536 +0x44a
mw-linkdave  | 
mw-linkdave  | goroutine 26859 gp=0x2fa13de0f860 m=nil [chan receive]:
mw-linkdave  | runtime.gopark(0x2fa13dd41a50?, 0x2fa13dd419d0?, 0x0?, 0x0?, 0x8dc8c8?)
mw-linkdave  | 	/usr/local/go/src/runtime/proc.go:462 +0xce fp=0x2fa13df99ec0 sp=0x2fa13df99ea0 pc=0x48852e
mw-linkdave  | runtime.chanrecv(0x2fa13dd419d0, 0x0, 0x1)
mw-linkdave  | 	/usr/local/go/src/runtime/chan.go:667 +0x4ae fp=0x2fa13df99f38 sp=0x2fa13df99ec0 pc=0x41c4ee
mw-linkdave  | runtime.chanrecv1(0x989680?, 0x0?)
mw-linkdave  | 	/usr/local/go/src/runtime/chan.go:509 +0x12 fp=0x2fa13df99f60 sp=0x2fa13df99f38 pc=0x41c012
mw-linkdave  | github.com/tosone/minimp3.NewDecoder.func2()
mw-linkdave  | 	/go/pkg/mod/github.com/tosone/minimp3@v1.0.2/decode.go:109 +0xda fp=0x2fa13df99fe0 sp=0x2fa13df99f60 pc=0x6c8c5a
mw-linkdave  | runtime.goexit({})
mw-linkdave  | 	/usr/local/go/src/runtime/asm_amd64.s:1771 +0x1 fp=0x2fa13df99fe8 sp=0x2fa13df99fe0 pc=0x48fbe1
mw-linkdave  | created by github.com/tosone/minimp3.NewDecoder in goroutine 26384
mw-linkdave  | 	/go/pkg/mod/github.com/tosone/minimp3@v1.0.2/decode.go:94 +0x228
mw-linkdave  | 
mw-linkdave  | rax    0x0
mw-linkdave  | rbx    0x2fa13e212014
mw-linkdave  | rcx    0x0
mw-linkdave  | rdx    0x0
mw-linkdave  | rdi    0x2fa13e41b550
mw-linkdave  | rsi    0x0
mw-linkdave  | rbp    0x0
mw-linkdave  | rsp    0x7fdc1e7f6720
mw-linkdave  | r8     0x2fa13e41b554
mw-linkdave  | r9     0x2fa13e212010
mw-linkdave  | r10    0x2fa13e212001
mw-linkdave  | r11    0x1fc
mw-linkdave  | r12    0x0
mw-linkdave  | r13    0x200
mw-linkdave  | r14    0x1fc
mw-linkdave  | r15    0x2fa13e212010
mw-linkdave  | rip    0x7cd21b
mw-linkdave  | rflags 0x10213
mw-linkdave  | cs     0x33
mw-linkdave  | fs     0x0
mw-linkdave  | gs     0x0
```