### PR TITLE
fix: audio sender leak

### DIFF
--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -93,12 +93,14 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 		return nil
 	}
 
+	var disconnected atomic.Bool
+
 	var vc voice.Conn
 	vc = voice.NewConn(
 		c.guildID,
 		c.userID,
 		func(ctx context.Context, guildID snowflake.ID, channelID *snowflake.ID, selfMute, selfDeaf bool) error {
-			if channelID != nil || vc == nil || c.closed.Load() {
+			if channelID != nil || vc == nil || disconnected.Swap(true) {
 				return nil
 			}
 


### PR DESCRIPTION
audio sender leak introduced in #77

## Before
```
❯ zsh /tmp/monitor.sh
13:52:51 total=6 audio= gw_l=0 gw_h=0 leak109=0
13:57:51 total=46 audio=6 gw_l=6 gw_h=6 leak109=0
14:02:51 total=46 audio=7 gw_l=6 gw_h=6 leak109=0
14:07:51 total=51 audio=9 gw_l=7 gw_h=7 leak109=0
14:12:51 total=48 audio=8 gw_l=5 gw_h=5 leak109=0                                                                                                                                                                       
14:17:51 total=47 audio=9 gw_l=5 gw_h=5 leak109=0
14:22:51 total=59 audio=12 gw_l=7 gw_h=7 leak109=0
14:27:51 total=55 audio=12 gw_l=7 gw_h=7 leak109=0
14:32:51 total=53 audio=11 gw_l=6 gw_h=6 leak109=0
14:37:51 total=57 audio=12 gw_l=7 gw_h=7 leak109=0
```
creeping up to ~30mb for 8 players after 23h

## After
```
❯ zsh /tmp/monitor.sh
14:42:51 total=24 audio= gw_l=0 gw_h=0 leak109=0
14:47:51 total=52 audio=7 gw_l=7 gw_h=7 leak109=0
14:52:51 total=45 audio=5 gw_l=5 gw_h=5 leak109=0
14:57:51 total=45 audio=7 gw_l=7 gw_h=7 leak109=0
15:02:51 total=43 audio=5 gw_l=5 gw_h=5 leak109=0
15:07:51 total=51 audio=7 gw_l=7 gw_h=7 leak109=0
15:12:51 total=53 audio=8 gw_l=8 gw_h=8 leak109=0
15:17:51 total=55 audio=9 gw_l=9 gw_h=9 leak109=0
```
stable at ~2mb for 9 players after 1h

<sub>
<code>total=N</code> all goroutines <br/>
<code>audio=N</code> audio sender goroutines (sends opus frames over UDP) <br/>
<code>gw_l=N</code> voice gateway listener goroutines (reads WebSocket from Discord voice server) <br/>
<code>gw_h=N</code> voice gateway heartbeat goroutines (sends keepalive pings) <br/>
<code>leak109=N</code> minimp3 decoder goroutines stuck (should always be 0) <br/>
</sub>