### PR TITLE
refactor: replace libdave with dave-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libopus-dev \
     libopusfile-dev \
-    gcc \
-    curl \
-    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ARCH=$(uname -m) && \
@@ -14,40 +11,6 @@ RUN ARCH=$(uname -m) && \
     cp /usr/lib/${ARCH}-linux-gnu/libopus.so.0*     /opt/libs/lib/ && \
     cp /usr/lib/${ARCH}-linux-gnu/libopusfile.so.0* /opt/libs/lib/ && \
     cp /usr/lib/${ARCH}-linux-gnu/libogg.so.0*      /opt/libs/lib/
-
-ENV LIBDAVE_VERSION=1.1.1
-
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        GITHUB_ARCH="X64"; \
-        SHA256="2470a131dbf39a820d893ba3d6f01373fc597868caffd6a30a8746e441ed5ede"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        GITHUB_ARCH="ARM64"; \
-        SHA256="2848ca62da5c8303626cfa410827f37735455f614256311fc320b35c7c6a1975"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    curl -fsL "https://github.com/discord/libdave/releases/download/v${LIBDAVE_VERSION}/cpp/libdave-Linux-${GITHUB_ARCH}-boringssl.zip" \
-        -o /tmp/libdave.zip && \
-    echo "${SHA256}  /tmp/libdave.zip" | sha256sum -c - && \
-    unzip -j /tmp/libdave.zip "include/dave/dave.h" -d /opt/libs/include && \
-    unzip -j /tmp/libdave.zip "lib/libdave.so"      -d /opt/libs/lib && \
-    rm /tmp/libdave.zip
-
-RUN mkdir -p /opt/libs/lib/pkgconfig && printf "\
-prefix=/opt/libs\n\
-exec_prefix=\${prefix}\n\
-libdir=\${exec_prefix}/lib\n\
-includedir=\${prefix}/include\n\
-\n\
-Name: dave\n\
-Description: Discord DAVE Protocol\n\
-Version: %s\n\
-Libs: -L\${libdir} -ldave -Wl,-rpath,/usr/lib\n\
-Cflags: -I\${includedir}\n" "${LIBDAVE_VERSION}" > /opt/libs/lib/pkgconfig/dave.pc
-
-ENV PKG_CONFIG_PATH=/opt/libs/lib/pkgconfig
-ENV LD_LIBRARY_PATH=/opt/libs/lib
 
 WORKDIR /app
 
@@ -70,7 +33,6 @@ FROM gcr.io/distroless/cc-debian13
 
 COPY --from=builder /app/linkdave               /usr/local/bin/linkdave
 COPY --from=builder /app/healthcheck            /usr/local/bin/healthcheck
-COPY --from=builder /opt/libs/lib/libdave.so        /usr/lib/
 COPY --from=builder /opt/libs/lib/libopus.so.0      /usr/lib/
 COPY --from=builder /opt/libs/lib/libopusfile.so.0  /usr/lib/
 COPY --from=builder /opt/libs/lib/libogg.so.0       /usr/lib/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Linkdave is a golang rewrite of lavalink, aimed at performance, memory efficienc
 
 Interoperability in the server and client libraries is an absolute non-goal. Read the [Linkdave TypeScript library documentation](https://npmx.dev/package-docs/linkdave/v/latest) for more details and how to use it. Linkdave is built from the ground up to support [Discord Audio & Video End-to-End Encryption (DAVE)](https://daveprotocol.com/), which is also where the name comes from.
 
-A big difference is that tracks do not need to be resolved first, and therefore  are only fetched once at play time without needing another roundtrip.
+A big difference is that tracks do not need to be resolved first, and therefore are only fetched once at play time without needing another roundtrip.
 
 **The following sources are currently supported**
 - Remote MP3 files and streams
@@ -94,7 +94,7 @@ You can interact with the server over http with the following methods and paths.
 |---|---|---|
 | `GET` | `/health` | Health check |
 | `GET` | `/stats` | Server statistics |
-| `GET` | `/ws` | Health check |
+| `GET` | `/ws` | WebSocket endpoint |
 | `POST` | `/sessions/{session_id}/players/{guild_id}/play` | Play a track for a player in a session |
 | `POST` | `/sessions/{session_id}/players/{guild_id}/pause` | Pause the current track |
 | `POST` | `/sessions/{session_id}/players/{guild_id}/resume` | Resume the paused track |
@@ -145,7 +145,7 @@ docker compose restart linkdave
 ```
 
 ### Binary Deployment
-Alternatively, you can download the latest binary release from the [GitHub Releases page](https://github.com/shi-gg/linkdave/releases) and run it directly on your server. Linkdave bundles it's own DAVE library for [Discord Audio E2EE](https://daveprotocol.com) inside the binary and the Docker image, therefor no `libdave.so` has to be installed.
+Alternatively, you can download the latest binary release from the [GitHub Releases page](https://github.com/shi-gg/linkdave/releases) and run it directly on your server. Linkdave bundles its own DAVE library for [Discord Audio E2EE](https://daveprotocol.com) inside the binary and the Docker image, therefore no `libdave.so` has to be installed.
 
 To start the server, run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I3I6AFVAP)
 
 ## About
-Linkdave is a golang rewrite of lavalink, aimed at performance, memory efficiency (lavalink @ 393mb-5.4gb vs linkdave @ 3mb with 38 players*), stability and several other things for [Wamellow](https://wamellow.com/docs/text-to-speech).
+Linkdave is a golang rewrite of lavalink, aimed at performance, memory efficiency (lavalink @ 393mb-5.4gb vs linkdave @ 3mb with 38 players*), stability and several other things for [Wamellow Text-to-Speech](https://wamellow.com/docs/text-to-speech).
 
 Interoperability in the server and client libraries is an absolute non-goal. Read the [Linkdave TypeScript library documentation](https://npmx.dev/package-docs/linkdave/v/latest) for more details and how to use it. Linkdave is built from the ground up to support [Discord Audio & Video End-to-End Encryption (DAVE)](https://daveprotocol.com/), which is also where the name comes from.
 
 A big difference is that tracks do not need to be resolved first, and therefore are only fetched once at play time without needing another roundtrip.
 
-**The following sources are currently supported**
+**You can use the following sources to play audio**
 - Remote MP3 files and streams
 - Text to Speech (using the [Wamellow TTS API](https://wamellow.com/docs/text-to-speech))
 <br />
@@ -25,15 +25,15 @@ await player.play(constructUri.tts("Hello world", "en_female_samc")); // Text to
 
 Tracks can also be queued
 ```ts
-const player = linkdave.getPlayer("GUILD_ID"); // <- GET or CREATE player
+const player = linkdave.getPlayer("GUILD_ID");
 await player.connect("VOICE_CHANNEL_ID");
 
-player.queue.add("https://icepool.silvacast.com/GAYFM.mp3"); // 24/7 radio stream
+player.queue.add("https://icepool.silvacast.com/GAYFM.mp3");
 await player.queue.start();
 ```
 <br />
 
-**The following filters are currently supported**
+**You can use the following filters to modify audio**
 - Vaporwave
 - Nightcore
 - Rotation
@@ -70,8 +70,8 @@ If you need help using this, [join our Discord Server](https://discord.com/invit
 
 Linkdave consists of a Go-based audio server that manages Discord voice connections and playback.
 
-- **WebSocket (`/ws`):** Provides a persistent connection for real-time events.
-- **REST API:** Exposes endpoints to control playback operations.
+- **WebSocket:** Provides a persistent connection for real-time events.
+- **API:** Exposes endpoints to control playback operations.
 
 The server leverages custom audio processing to directly pipeline from an audio source into Discord's UDP socket for low-latency streaming without relying on external bloat.
 
@@ -87,6 +87,7 @@ The following env variables can be set for the server.
 | `LINKDAVE_SOURCE_TEXT_TO_SPEECH_URL` | string | `tts.wamellow.com/api/invoke` | Text-to-speech API endpoint |
 | `LINKDAVE_SOURCE_TEXT_TO_SPEECH_TOKEN` | string | — | Authentication token for the TTS API |
 | `LINKDAVE_PASSWORD` | string | — | Application password |
+| `LINKDAVE_LOG_LEVEL` | string | `INFO` | Log level (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 
 You can interact with the server over http with the following methods and paths.
 
@@ -102,7 +103,7 @@ You can interact with the server over http with the following methods and paths.
 | `POST` | `/sessions/{session_id}/players/{guild_id}/seek` | Seek to a position in the track |
 | `DELETE` | `/sessions/{session_id}/players/{guild_id}` | Disconnect and destroy the player |
 
-<sub>For the list of gateway events and their behavior, please read the source code</sub>
+<sub>Regarding the list of gateway events and their behavior, please read the source code.</sub>
 
 ### Docker Deployment
 To deploy Linkdave using Docker, you can use the following `compose.yml` configuration. This setup exposes the WebSocket API on port 8080 and includes health checks to ensure the service is running properly.

--- a/README.md
+++ b/README.md
@@ -3,22 +3,71 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I3I6AFVAP)
 
-**⚠️ In development, breaking changes ⚠️**
-
 ## About
-Linkdave is a golang rewrite of lavalink, aimed at performance, memory efficiency (lavalink @ 393mb-5.4gb vs linkdave @ 4mb with 38 players*), stability and several other things for [Wamellow](https://wamellow.com/docs/text-to-speech).
+Linkdave is a golang rewrite of lavalink, aimed at performance, memory efficiency (lavalink @ 393mb-5.4gb vs linkdave @ 3mb with 38 players*), stability and several other things for [Wamellow](https://wamellow.com/docs/text-to-speech).
 
 Interoperability in the server and client libraries is an absolute non-goal. Read the [Linkdave TypeScript library documentation](https://npmx.dev/package-docs/linkdave/v/latest) for more details and how to use it. Linkdave is built from the ground up to support [Discord Audio & Video End-to-End Encryption (DAVE)](https://daveprotocol.com/), which is also where the name comes from.
 
-The following sources are currently supported:
+A big difference is that tracks do not need to be resolved first, and therefore  are only fetched once at play time without needing another roundtrip.
+
+**The following sources are currently supported**
 - Remote MP3 files and streams
 - Text to Speech (using the [Wamellow TTS API](https://wamellow.com/docs/text-to-speech))
+<br />
+
+```ts
+const player = linkdave.getPlayer("GUILD_ID"); // <- GET or CREATE player
+await player.connect("VOICE_CHANNEL_ID");
+
+await player.play("https://icepool.silvacast.com/GAYFM.mp3"); // 24/7 radio stream
+await player.play(constructUri.tts("Hello world", "en_female_samc")); // Text to Speech
+```
+
+Tracks can also be queued
+```ts
+const player = linkdave.getPlayer("GUILD_ID"); // <- GET or CREATE player
+await player.connect("VOICE_CHANNEL_ID");
+
+player.queue.add("https://icepool.silvacast.com/GAYFM.mp3"); // 24/7 radio stream
+await player.queue.start();
+```
+<br />
+
+**The following filters are currently supported**
+- Vaporwave
+- Nightcore
+- Rotation
+- Tremolo
+- Vibrato
+- LowPass
+- Customizable Pitch
+- Customizable Speed
+<br />
+
+```ts
+// every track after the current one
+player.filters.toggle(Filter.Nightcore)
+player.filters.speed = 0.5;
+player.filters.pitch = 0.5;
+
+// single track only (works on `player.play` as well)
+player.queue.add(
+    constructUri.tts(fullText, voice, translate),
+    {
+        requesterId: message.author.id,
+        filters: {
+            enabled: [Filter.Vaporwave],
+            speed: 0.5,
+            pitch: 0.5
+        }
+    }
+);
+```
 
 If you need help using this, [join our Discord Server](https://discord.com/invite/yYd6YKHQZH).
 
 ## Setup & Usage
 
-### ⚙️ How the Server Works
 Linkdave consists of a Go-based audio server that manages Discord voice connections and playback.
 
 - **WebSocket (`/ws`):** Provides a persistent connection for real-time events.
@@ -26,7 +75,36 @@ Linkdave consists of a Go-based audio server that manages Discord voice connecti
 
 The server leverages custom audio processing to directly pipeline from an audio source into Discord's UDP socket for low-latency streaming without relying on external bloat.
 
-#### Docker Deployment
+The following env variables can be set for the server.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `LINKDAVE_SOURCE_HTTP_ENABLED` | bool | `false` | Enable HTTP source checking |
+| `LINKDAVE_SOURCE_HTTPS_ENABLED` | bool | `false` | Enable HTTPS source checking |
+| `LINKDAVE_SOURCE_IP_ADDRESS_PUBLIC_ENABLED` | bool | `false` | Enable public IP address source |
+| `LINKDAVE_SOURCE_IP_ADDRESS_PRIVATE_ENABLED` | bool | `false` | Enable private IP address source |
+| `LINKDAVE_SOURCE_TEXT_TO_SPEECH_ENABLED` | bool | `false` | Enable text-to-speech source |
+| `LINKDAVE_SOURCE_TEXT_TO_SPEECH_URL` | string | `tts.wamellow.com/api/invoke` | Text-to-speech API endpoint |
+| `LINKDAVE_SOURCE_TEXT_TO_SPEECH_TOKEN` | string | — | Authentication token for the TTS API |
+| `LINKDAVE_PASSWORD` | string | — | Application password |
+
+You can interact with the server over http with the following methods and paths.
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/health` | Health check |
+| `GET` | `/stats` | Server statistics |
+| `GET` | `/ws` | Health check |
+| `POST` | `/sessions/{session_id}/players/{guild_id}/play` | Play a track for a player in a session |
+| `POST` | `/sessions/{session_id}/players/{guild_id}/pause` | Pause the current track |
+| `POST` | `/sessions/{session_id}/players/{guild_id}/resume` | Resume the paused track |
+| `POST` | `/sessions/{session_id}/players/{guild_id}/stop` | Stop the current track |
+| `POST` | `/sessions/{session_id}/players/{guild_id}/seek` | Seek to a position in the track |
+| `DELETE` | `/sessions/{session_id}/players/{guild_id}` | Disconnect and destroy the player |
+
+<sub>For the list of gateway events and their behavior, please read the source code</sub>
+
+### Docker Deployment
 To deploy Linkdave using Docker, you can use the following `compose.yml` configuration. This setup exposes the WebSocket API on port 8080 and includes health checks to ensure the service is running properly.
 
 `compose.yml`:
@@ -50,7 +128,6 @@ services:
 ```
 
 To generate a random password, you can use the following command in your terminal:
-
 ```bash
 echo "LINKDAVE_PASSWORD=$(openssl rand -hex 16)" >> .env
 cat .env
@@ -67,90 +144,18 @@ docker pull ghcr.io/shi-gg/linkdave:latest
 docker compose restart linkdave
 ```
 
-#### Binary Deployment
-Alternatively, you can download the latest binary release from the [GitHub Releases page](https://github.com/shi-gg/linkdave/releases) and run it directly on your server.
+### Binary Deployment
+Alternatively, you can download the latest binary release from the [GitHub Releases page](https://github.com/shi-gg/linkdave/releases) and run it directly on your server. Linkdave bundles it's own DAVE library for [Discord Audio E2EE](https://daveprotocol.com) inside the binary and the Docker image, therefor no `libdave.so` has to be installed.
 
-> [!CAUTION]
-> Linkdave relies on a C library, `libdave.so` from [discord/libdave](https://github.com/discord/libdave), for [Discord Audio E2EE](https://daveprotocol.com). This library is included in the Docker image, but not the binary.
-
-When using the standalone `linkdave-linux-amd64` binary, the system needs to know where to find the `libdave.so` shared library. Without it, the application will fail to launch, and running `ldd linkdave-linux-amd64` will report `libdave.so => not found`.
-
-To download the library, go to the [libdave releases page](https://github.com/discord/libdave/releases) and download the `libdave-Linux-X64-boringssl.zip` asset. Extract the `lib/libdave.so` file and follow one of the installation methods below.
-
-<details>
-
-<summary>Installing the `libdave.so` library</summary>
-
-Choose one of the methods below based on your OS and whether you want a system-wide or portable installation.
-
-##### Method 1: System-Wide Installation (Recommended)
-Installing the library system-wide allows you to run `linkdave-linux-amd64` from anywhere without needing to set environment variables.
-
-###### Ubuntu / Debian
-On Ubuntu and Debian systems, the standard directory for local 64-bit shared libraries is `/usr/local/lib`.
-
+To start the server, run:
 ```bash
-# 1. Copy the library to the standard path
-sudo cp libdave.so /usr/local/lib/
+curl -L -o linkdave https://github.com/shi-gg/linkdave/releases/latest/download/linkdave-linux-amd64
+chmod +x linkdave
 
-# 2. Update the dynamic linker cache
-sudo ldconfig
-
-# 3. Make the binary executable
-chmod +x ./linkdave-linux-amd64
-
-# 4. Verify the library is found (it should map to /usr/local/lib/libdave.so)
-ldd ./linkdave-linux-amd64 | grep libdave
+LINKDAVE_SOURCE_HTTPS_ENABLED=true LINKDAVE_SOURCE_IP_ADDRESS_PUBLIC_ENABLED=true ./linkdave
 ```
 
-###### RHEL / Fedora / CentOS
-On Red Hat-based systems, 64-bit libraries belong in `/usr/local/lib64`.
-Depending on your system configuration, you might also need to explicitly add this directory to the linker's search path.
-
-```bash
-# 1. Create the directory (if it doesn't exist) and copy the library
-sudo mkdir -p /usr/local/lib64
-sudo cp libdave.so /usr/local/lib64/
-
-# 2. Ensure the directory is in the linker's search path
-echo "/usr/local/lib64" | sudo tee /etc/ld.so.conf.d/local64.conf
-
-# 3. Update the dynamic linker cache
-sudo ldconfig
-
-# 4. Make the binary executable
-chmod +x ./linkdave-linux-amd64
-
-# 5. Verify the library is found (it should map to /usr/local/lib64/libdave.so)
-ldd ./linkdave-linux-amd64 | grep libdave
-```
-
----
-
-##### Method 2: Portable Setup (No Root Required)
-If you do not have `sudo` access or prefer to keep the binary and library together in a self-contained folder, you can run the binary by explicitly passing the library path at runtime.
-
-Ensure `libdave.so` and `linkdave-linux-amd64` are in the same folder.
-
-```bash
-# 1. Make the binary executable
-chmod +x ./linkdave-linux-amd64
-
-# 2. Run the binary with LD_LIBRARY_PATH set to the current directory
-LD_LIBRARY_PATH=. ./linkdave-linux-amd64
-```
-
----
-
-##### Run the binary
-
-```bash
-LINKDAVE_SOURCE_HTTPS_ENABLED=true LINKDAVE_SOURCE_IP_ADDRESS_PUBLIC_ENABLED=true ./linkdave-linux-amd64
-```
-
-</details>
-
-### 💻 Using the Client Library (TypeScript)
+## Using the Client Library (TypeScript)
 Linkdave provides a robust, fully type-safe, TypeScript client for seamless interaction.
 
 There is a quick example bot inside the [`example/`](https://github.com/shi-gg/linkdave/blob/main/example/index.ts) directory, and a deploy ready 24/7 radio music bot at [github.com/shi-gg/radio-bot](https://github.com/shi-gg/radio-bot).
@@ -192,7 +197,7 @@ await player.play("https://icepool.silvacast.com/GAYFM.mp3");
 discord.login(process.env.DISCORD_TOKEN);
 ```
 
-### 🔄 Seamless Node Migrations & Graceful Shutdown
+## Seamless Node Migrations & Graceful Shutdown
 Linkdave is built for high availability. When a server node needs to shut down (e.g., for an update or maintenance), it can do so without dropping any active audio streams across your bots using **Graceful Migrations**.
 
 1. **Draining Mode:** Upon receiving a `SIGINT` or `SIGTERM`, the Linkdave server enters "draining" mode. It stops accepting new players and broadcasts a `NodeDraining` message via the WebSocket to all connected clients.

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "linkdave",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "author": "Luna Seemann <luna@wamellow.com> (http://shi.gg)",
     "description": "TypeScript client library for linkdave Discord audio streaming server",
     "repository": {

--- a/go.mod
+++ b/go.mod
@@ -3,23 +3,23 @@ module github.com/shi-gg/linkdave
 go 1.26.2
 
 require (
-	github.com/disgoorg/disgo v0.19.4-0.20260513223554-8fafd9677292
-	github.com/disgoorg/godave/golibdave v0.1.0
+	github.com/disgoorg/disgo v0.19.4
 	github.com/disgoorg/snowflake/v2 v2.0.3
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hraban/opus v0.0.0-20251117090126-c76ea7e21bf3
 	github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82
+	github.com/thomas-vilte/dave-go v0.2.2
 )
 
 require (
 	github.com/disgoorg/godave v0.1.0 // indirect
-	github.com/disgoorg/godave/libdave v0.1.0 // indirect
 	github.com/disgoorg/json/v2 v2.0.0 // indirect
 	github.com/disgoorg/omit v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/sasha-s/go-csync v0.0.0-20240107134140-fcbab37b09ad // indirect
+	github.com/thomas-vilte/mls-go v1.3.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/disgoorg/disgo v0.19.4-0.20260513223554-8fafd9677292 h1:isRIv6GcGuPlMQc8zUopO81uIMdamqC5M4eGZg4OxcU=
-github.com/disgoorg/disgo v0.19.4-0.20260513223554-8fafd9677292/go.mod h1:NnV63iw4lJdF1fnV0gX27XR43ZgRGqnL122svRMTgTE=
+github.com/disgoorg/disgo v0.19.4 h1:Jz7UHte4bOGESNbNIbPhZCdX9iJw5PHU7Fu2Afdi+bY=
+github.com/disgoorg/disgo v0.19.4/go.mod h1:NnV63iw4lJdF1fnV0gX27XR43ZgRGqnL122svRMTgTE=
 github.com/disgoorg/godave v0.1.0 h1:3g0Zqzz+zNaxQTVLfCnl5eZKGqZk6cM/JLLbMKCtZQQ=
 github.com/disgoorg/godave v0.1.0/go.mod h1:OreAC3hpabr39bMVA+jwOVDq1EUPXH5A0XUBiZaDI1Y=
-github.com/disgoorg/godave/golibdave v0.1.0 h1:ga70vTb2pCdFgu+Jq8KteE9qLhezG5dI4H0vB/+6vBQ=
-github.com/disgoorg/godave/golibdave v0.1.0/go.mod h1:u9INYjfw/FE0Evjr3dWjaYsaVfQcX+zNf+ZNQjROt6A=
-github.com/disgoorg/godave/libdave v0.1.0 h1:1HDvN9ORP23OgV4CDudol/EprgGeTOKuRvANh5eNsow=
-github.com/disgoorg/godave/libdave v0.1.0/go.mod h1:CxundbQ722MpK3vD31kaOAxbu1+cFnnEKQDqQ7rpxEM=
 github.com/disgoorg/json/v2 v2.0.0 h1:U16yy/ARK7/aEpzjjqK1b/KaqqGHozUdeVw/DViEzQI=
 github.com/disgoorg/json/v2 v2.0.0/go.mod h1:jZTBC0nIE1WeetSEI3/Dka8g+qglb4FPVmp5I5HpEfI=
 github.com/disgoorg/omit v1.0.0 h1:y0LkVUOyUHT8ZlnhIAeOZEA22UYykeysK8bLJ0SfT78=
@@ -40,6 +36,10 @@ github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82 h1:CHFvPPb5wLYOZD
 github.com/shi-gg/minimp3 v1.0.3-0.20260601110419-3b34065acf82/go.mod h1:hAMWIl1N2SX+bWOcDRszUNf1sp0fYkPb0AY5xvqvA/Q=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/thomas-vilte/dave-go v0.2.2 h1:JrGVv/V8fo0oIAkcMkep93TnDalwjV90aa85aK2rbIo=
+github.com/thomas-vilte/dave-go v0.2.2/go.mod h1:reNyhubMlctm0r07p8pgCQqLtc2aMu41YEghhr8J5DY=
+github.com/thomas-vilte/mls-go v1.3.0 h1:iJvXCOAkIKiZZ1L5q8jPvsJ+HgZ9VHymEr4BYvnWU7E=
+github.com/thomas-vilte/mls-go v1.3.0/go.mod h1:bgIvQH/BHyfcFDuro1CLeqXASSJPFXIJ79WqJuzlRLM=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=

--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -11,10 +11,10 @@ import (
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/disgo/voice"
-	"github.com/disgoorg/godave/golibdave"
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/shi-gg/linkdave/server/audio/source"
 	"github.com/shi-gg/linkdave/server/protocol"
+	"github.com/thomas-vilte/dave-go/session"
 )
 
 type Connection struct {
@@ -138,7 +138,7 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 			c.mutex.Unlock()
 		},
 		voice.WithConnLogger(c.logger),
-		voice.WithConnDaveSessionCreateFunc(golibdave.NewSession),
+		voice.WithConnDaveSessionCreateFunc(session.New),
 	)
 
 	openCtx, openCancel := context.WithCancel(ctx)


### PR DESCRIPTION
Tested in production at [Wamellow](https://wamelow.com/docs/text-to-speech) with 171 players (4h uptime @ 13mb memory usage) 