### PR TITLE
fix: handle unexpected EOF

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import type { FiltersPayload } from "linkdave";
+import type { FiltersPayload, Player } from "linkdave";
 import { Client, Events, GatewayIntentBits } from "discord.js";
 import { constructUri, EventName, Filter, LinkDaveClient } from "linkdave";
 
@@ -136,8 +136,33 @@ discord.on(Events.MessageCreate, async (msg) => {
             player.filters.clear();
             break;
         }
+        case "!status": {
+            msg.reply(`\`\`\`${JSON.stringify(playerToJson(player))}\`\`\``)
+            break;
+        }
+        case "!kill": linkdave.removeNode(player.node.name); break;
     }
 });
+
+function playerToJson(player: Player) {
+    return {
+        connected: player.connected,
+        playing: player.playing,
+        paused: player.paused,
+        state: player.state,
+        current: player.current,
+        filters: {
+            activeFilters: player.filters.activeFilters,
+            pitch: player.filters.pitch,
+            speed: player.filters.speed
+        },
+        queue: {
+            size: player.queue.size,
+            active: player.queue.active,
+            next: player.queue.tracks[0]
+        }
+    };
+}
 
 process.on("SIGINT", () => {
     linkdave.disconnectAll();

--- a/server/server/websocket.go
+++ b/server/server/websocket.go
@@ -253,6 +253,10 @@ func (s *Server) handleVoiceUpdate(client *Client, data json.RawMessage) {
 	err := s.voiceManager.Connect(ctx, client.sessionID, update.ClientID, update.GuildID, update.ChannelID, update.SessionID, update.Event)
 	if err != nil {
 		s.logger.Error("failed to connect to voice", slog.Any("error", err))
+		client.removePlayer(update.GuildID)
+		if disconnectErr := s.voiceManager.Disconnect(client.sessionID, update.GuildID); disconnectErr != nil {
+			s.logger.Error("failed to clean up failed voice connection", slog.Any("error", disconnectErr))
+		}
 
 		client.send(protocol.Message{
 			Op: protocol.OpVoiceDisconnect,

--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -229,15 +229,21 @@ func (c *Connection) scheduleUnexpectedDisconnect() {
 
 func (c *Connection) handleUnexpectedDisconnect() {
 	c.mutex.Lock()
-	timer := c.staleTimer
-	c.staleTimer = nil
-	stale := c.voiceConn == nil && c.targetVoiceConn == nil
-	c.mutex.Unlock()
 
-	if timer == nil || !stale || c.closed.Swap(true) {
+	if c.staleTimer == nil {
+		c.mutex.Unlock()
 		return
 	}
 
+	c.staleTimer = nil
+	stale := c.voiceConn == nil && c.targetVoiceConn == nil
+
+	if !stale || c.closed.Swap(true) {
+		c.mutex.Unlock()
+		return
+	}
+
+	c.mutex.Unlock()
 	c.logger.Info("sending unexpected disconnect", slog.String("guild_id", c.guildID.String()))
 
 	c.Stop()

--- a/server/voice/connection.go
+++ b/server/voice/connection.go
@@ -37,6 +37,8 @@ type Connection struct {
 	setupCancel context.CancelFunc
 
 	stopChan chan struct{}
+
+	staleTimer *time.Timer
 }
 
 func NewConnection(
@@ -66,18 +68,13 @@ func NewConnection(
 }
 
 func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID, sessionID string, event protocol.VoiceServerEvent) error {
+	c.cancelStaleTimer()
+
 	c.mutex.Lock()
 	if c.setupCancel != nil {
 		c.setupCancel()
 	}
-	oldVC := c.voiceConn
 	c.mutex.Unlock()
-
-	if oldVC != nil {
-		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		oldVC.Close(closeCtx)
-		cancel()
-	}
 
 	c.setupMu.Lock()
 	defer c.setupMu.Unlock()
@@ -87,11 +84,8 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 	}
 
 	c.mutex.Lock()
-	alreadySetUp := c.voiceConn != nil && c.voiceConn != oldVC
+	oldVC := c.voiceConn
 	c.mutex.Unlock()
-	if alreadySetUp {
-		return nil
-	}
 
 	var disconnected atomic.Bool
 
@@ -122,20 +116,24 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 			return nil
 		},
 		func() {
-			c.logger.Debug("voice connection removed from manager")
-
-			if c.closed.Load() {
-				return
-			}
+			c.logger.Debug("voice connection removed from manager", slog.String("guild_id", c.guildID.String()))
 
 			c.mutex.Lock()
-			if c.voiceConn == vc {
+			wasCurrent := c.voiceConn == vc
+			replacing := wasCurrent && c.targetVoiceConn != nil
+			if wasCurrent {
 				c.voiceConn = nil
 			}
 			if c.targetVoiceConn == vc {
 				c.targetVoiceConn = nil
 			}
 			c.mutex.Unlock()
+
+			if !wasCurrent || replacing || c.closed.Load() {
+				return
+			}
+
+			c.scheduleUnexpectedDisconnect()
 		},
 		voice.WithConnLogger(c.logger),
 		voice.WithConnDaveSessionCreateFunc(session.New),
@@ -147,6 +145,12 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 	c.setupCancel = openCancel
 	c.targetVoiceConn = vc
 	c.mutex.Unlock()
+
+	if oldVC != nil {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		oldVC.Close(closeCtx)
+		cancel()
+	}
 
 	vc.HandleVoiceStateUpdate(gateway.EventVoiceStateUpdate{
 		VoiceState: discord.VoiceState{
@@ -182,13 +186,62 @@ func (c *Connection) setupVoiceConn(ctx context.Context, channelID snowflake.ID,
 	}
 
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.targetVoiceConn != vc {
+		return fmt.Errorf("voice connection closed during setup")
+	}
+
 	c.voiceConn = vc
 	c.targetVoiceConn = nil
 	c.channelID = channelID
 	vc.SetOpusFrameProvider(&trackWrapper{conn: c})
-	c.mutex.Unlock()
 
 	return nil
+}
+
+func (c *Connection) cancelStaleTimer() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.staleTimer == nil {
+		return
+	}
+
+	c.staleTimer.Stop()
+	c.staleTimer = nil
+}
+
+func (c *Connection) scheduleUnexpectedDisconnect() {
+	if c.closed.Load() {
+		return
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.staleTimer != nil {
+		c.staleTimer.Stop()
+	}
+
+	c.staleTimer = time.AfterFunc(time.Second, c.handleUnexpectedDisconnect)
+}
+
+func (c *Connection) handleUnexpectedDisconnect() {
+	c.mutex.Lock()
+	timer := c.staleTimer
+	c.staleTimer = nil
+	stale := c.voiceConn == nil && c.targetVoiceConn == nil
+	c.mutex.Unlock()
+
+	if timer == nil || !stale || c.closed.Swap(true) {
+		return
+	}
+
+	c.logger.Info("sending unexpected disconnect", slog.String("guild_id", c.guildID.String()))
+
+	c.Stop()
+	c.onDisconnect()
 }
 
 func (c *Connection) HandleVoiceUpdate(ctx context.Context, channelID snowflake.ID, sessionID string, event protocol.VoiceServerEvent) error {
@@ -343,6 +396,8 @@ func (c *Connection) Close() {
 	if c.closed.Swap(true) {
 		return
 	}
+
+	c.cancelStaleTimer()
 	c.Stop()
 
 	c.mutex.Lock()
@@ -355,9 +410,7 @@ func (c *Connection) Close() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	vc.Close(ctx)
 
-	c.logger.Debug("voice connection closed",
-		slog.String("guild_id", c.guildID.String()),
-	)
+	vc.Close(ctx)
+	c.logger.Debug("voice connection closed", slog.String("guild_id", c.guildID.String()))
 }

--- a/server/voice/manager.go
+++ b/server/voice/manager.go
@@ -84,11 +84,14 @@ func (m *Manager) Connect(ctx context.Context, sessionID string, userID, guildID
 	}
 
 	var conn *Connection
-	conn, err := NewConnection(ctx, m.logger, userID, guildID, channelID, discordSessionID, event, func(src source.Source, reason string, err error) {
-		m.onTrackEnd(sessionID, guildID, src, reason, err)
-	}, func() {
-		m.onDisconnect(sessionID, guildID, conn, key)
-	})
+	conn, err := NewConnection(ctx, m.logger, userID, guildID, channelID, discordSessionID, event,
+		func(src source.Source, reason string, err error) {
+			m.onTrackEnd(sessionID, guildID, src, reason, err)
+		},
+		func() {
+			m.onDisconnect(sessionID, guildID, conn, key)
+		},
+	)
 
 	if err != nil {
 		return fmt.Errorf("failed to create voice connection: %w", err)


### PR DESCRIPTION
Fixes `unexpected EOF` desyncs (player wasn't cleaned up properly)
```js
linkdave  | {"time":"2026-06-17T05:17:20.894117998Z","level":"DEBUG","msg":"sending voice gateway command","name":"voice_conn","name":"voice_conn_gateway","data":"{\"op\":3,\"d\":{\"t\":1781673440894,\"seq_ack\":6}}"}
linkdave  | {"time":"2026-06-17T05:17:20.980277349Z","level":"DEBUG","msg":"received voice gateway message","name":"voice_conn","name":"voice_conn_gateway","data":"{\"op\":6,\"d\":{\"t\":1781673440894}}"}
linkdave  | {"time":"2026-06-17T05:17:34.464145176Z","level":"WARN","msg":"voice gateway close received","name":"voice_conn","name":"voice_conn_gateway","reconnect":true,"code":1006,"error":"unexpected EOF"}
linkdave  | {"time":"2026-06-17T05:17:34.464173072Z","level":"DEBUG","msg":"closing heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.464180387Z","level":"DEBUG","msg":"closing voice gateway connection","name":"voice_conn","name":"voice_conn_gateway","code":1012,"message":"reconnecting"}
linkdave  | {"time":"2026-06-17T05:17:34.464259551Z","level":"DEBUG","msg":"exiting voice heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.464272208Z","level":"DEBUG","msg":"exiting listen goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.464303957Z","level":"DEBUG","msg":"opening voice gateway connection","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.683092107Z","level":"DEBUG","msg":"received voice gateway message","name":"voice_conn","name":"voice_conn_gateway","data":"{\"op\":8,\"d\":{\"v\":8,\"heartbeat_interval\":13750}}"}
linkdave  | {"time":"2026-06-17T05:17:34.68313324Z","level":"DEBUG","msg":"sending Resume command","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.683179104Z","level":"DEBUG","msg":"sending voice gateway command","name":"voice_conn","name":"voice_conn_gateway","data":"{\"op\":7,\"d\":{\"server_id\":\"908450210726944808\",\"session_id\":\"f37573476d10c46f43a5b25d7500ec72\",\"token\":\"189251329be3f4f6\",\"seq\":6}}"}
linkdave  | {"time":"2026-06-17T05:17:34.717030261Z","level":"DEBUG","msg":"exiting listen goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.717042805Z","level":"DEBUG","msg":"closing heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.717047308Z","level":"DEBUG","msg":"closing voice gateway connection","name":"voice_conn","name":"voice_conn_gateway","code":1000,"message":"Shutting down"}
linkdave  | {"time":"2026-06-17T05:17:34.717222065Z","level":"DEBUG","msg":"exiting voice heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.719100025Z","level":"ERROR","msg":"failed to reopen voice gateway","name":"voice_conn","name":"voice_conn_gateway","err":"failed to open voice gateway connection: websocket: close 4006: Session is no longer valid."}
linkdave  | {"time":"2026-06-17T05:17:34.719125829Z","level":"DEBUG","msg":"closing heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.719127979Z","level":"DEBUG","msg":"closing heartbeat goroutine","name":"voice_conn","name":"voice_conn_gateway"}
linkdave  | {"time":"2026-06-17T05:17:34.719141328Z","level":"DEBUG","msg":"voice connection removed from manager","guild_id":"908450210726944808"}
linkdave  | {"time":"2026-06-17T05:17:34.719152553Z","level":"DEBUG","msg":"closing audio sender","name":"voice_conn"}
linkdave  | {"time":"2026-06-17T05:17:35.719363456Z","level":"INFO","msg":"sending unexpected disconnect","guild_id":"908450210726944808"}
```

was tested against rapid channel moves, normal disconnects, `player.destroy()`, and the `unexpected EOF`